### PR TITLE
Tic 1 - Screenings showing on frontpage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .vscode
 main.css.map
+main.css

--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# Kino på MARS!
+
+## Screenings
+
+The screenings route returns an object with a array of data containing upcoming screenings for the five coming days. Each screening in the array is an object with keys: id, title, movieId, image, start_time and room.
+
+- **URL**
+  /api/screenings
+
+- **Method:**
+  GET
+
+- **Success Response**
+  Code: 200
+  Content: `{ "data": [ { "id": 29, "title": "Threat Level Midnight: The Movie", "movieId": 10, "image": "https://m.media- amazon.com/images/M/MV5BZjMzNzE4ZGItMDI5Zi00ZjE3LThkODctYTlhZWY1ZTdmMGNjXkEyXkFqcGdeQXVyOTExNzM4NDM@._V1_.jpg", "start_time": "2022-01-31T12:00:00.000Z", "room": "Stora salongen" } ] }`

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
     "dev": "nodemon .",
     "start": "node .",
-    "watch": "sass --watch src/main.scss static/main.css"
+    "watch": "sass --watch src/main.scss static/main.css",
+    "build": "sass src/main.scss static/main.css"
   },
   "author": "Emil Noren",
   "license": "ISC",

--- a/src/app.js
+++ b/src/app.js
@@ -3,7 +3,7 @@ import { engine } from "express-handlebars";
 import { loadAllMovies, loadMovie } from "./movies.js";
 import { kino } from "./kinoBuilds.js";
 import { marked } from "marked";
-import getUpcomingScreenings from './screenings.js'
+import {getUpcomingScreenings} from './screenings.js'
 
 const app = express();
 

--- a/src/app.js
+++ b/src/app.js
@@ -35,7 +35,7 @@ app.get("/movies/:Id", async (request, response) => {
     : response.status(404).render("404", { kino });
 });
 
-app.get('/screenings', async (request, response) => {
+app.get('/api/screenings', async (request, response) => {
   try {
     const screeningsData = await getUpcomingScreenings();
     const jsonObj = {

--- a/src/app.js
+++ b/src/app.js
@@ -36,14 +36,12 @@ app.get("/movies/:Id", async (request, response) => {
 });
 
 app.get('/screenings', async (request, response) => {
-
   try {
     const screeningsData = await getUpcomingScreenings();
     const jsonObj = {
       data: screeningsData
     }
     const jsonData = JSON.stringify(jsonObj)
-
     response.json(JSON.parse(jsonData));
   } catch (error) {
     console.log(error)

--- a/src/app.js
+++ b/src/app.js
@@ -3,7 +3,7 @@ import { engine } from "express-handlebars";
 import { loadAllMovies, loadMovie } from "./movies.js";
 import { kino } from "./kinoBuilds.js";
 import { marked } from "marked";
-import {getUpcomingScreenings} from './screenings.js'
+import { getUpcomingScreenings } from './screenings.js'
 
 const app = express();
 

--- a/src/app.js
+++ b/src/app.js
@@ -3,6 +3,7 @@ import { engine } from "express-handlebars";
 import { loadAllMovies, loadMovie } from "./movies.js";
 import { kino } from "./kinoBuilds.js";
 import { marked } from "marked";
+import getUpcomingScreenings from './screenings.js'
 
 const app = express();
 
@@ -32,6 +33,21 @@ app.get("/movies/:Id", async (request, response) => {
   movie
     ? response.render("movie", { movie, kino })
     : response.status(404).render("404", { kino });
+});
+
+app.get('/screenings', async (request, response) => {
+
+  try {
+    const screeningsData = await getUpcomingScreenings();
+    const jsonObj = {
+      data: screeningsData
+    }
+    const jsonData = JSON.stringify(jsonObj)
+
+    response.json(JSON.parse(jsonData));
+  } catch (error) {
+    console.log(error)
+  }
 });
 
 app.use("/", express.static("./static"));

--- a/src/main.scss
+++ b/src/main.scss
@@ -30,4 +30,4 @@
 @import 'sections/reservation/reservationHero';
 @import 'sections/reservation/reservationInfo';
 @import 'sections/reservation/reservationSeats';
-@import 'sections/reservation/reservationfooter';
+@import 'sections/reservation/reservationFooter';

--- a/src/main.scss
+++ b/src/main.scss
@@ -6,7 +6,7 @@
 @import 'sections/hero';
 @import 'sections/comingSoon';
 @import 'sections/about';
-@import 'sections/movieCards';
+@import 'sections/screeningsCards';
 @import 'sections/ftMovie';
 @import 'sections/events';
 

--- a/src/screenings.js
+++ b/src/screenings.js
@@ -11,12 +11,13 @@ export function trimData (screeningsArray) {
       movieId: screening.attributes.movie.data.id,
       image: screening.attributes.movie.data.attributes.image.url,
       start_time: screening.attributes.start_time,
+      room: screening.attributes.room
     };
   });
   return trimmedArr;
 };
 
-const filterOldScreenings = (screenings, todaysDate) => {
+export function filterOldScreenings (screenings, todaysDate) {
   const upcomingScreenings = screenings.filter((screening) => {
     if (Date.parse(screening.start_time) > Date.parse(todaysDate)) {
       return screening;
@@ -25,7 +26,7 @@ const filterOldScreenings = (screenings, todaysDate) => {
   return upcomingScreenings;
 };
 
-const filterNextFiveDaysScreenings = (screenings, futureDate) => {
+export function filterNextFiveDaysScreenings (screenings, futureDate) {
   const filteredScreenings = screenings.filter((screening) => {
     if (Date.parse(screening.start_time) < Date.parse(futureDate)) {
       return screening;

--- a/src/screenings.js
+++ b/src/screenings.js
@@ -1,7 +1,7 @@
 import fetch from 'node-fetch';
 
 const API_BASEURL =
-  'https://lernia-kino-cms.herokuapp.com/api/screenings?populate=movie';
+  'https://lernia-kino-cms.herokuapp.com/api/screenings?populate=movie&pagination[pageSize]=1500';
 
 const trimData = (screening) => {
   return {

--- a/src/screenings.js
+++ b/src/screenings.js
@@ -9,7 +9,7 @@ const trimData = (screening) => {
     title: screening.attributes.movie.data.attributes.title,
     movieId: screening.attributes.movie.data.id,
     image: screening.attributes.movie.data.attributes.image.url,
-    ...screening.attributes,
+    start_time: screening.attributes.start_time,
   };
 };
 

--- a/src/screenings.js
+++ b/src/screenings.js
@@ -1,0 +1,79 @@
+import fetch from 'node-fetch';
+
+const API_BASEURL =
+  'https://lernia-kino-cms.herokuapp.com/api/screenings?populate=movie';
+
+const trimData = (screening) => {
+  return {
+    id: screening.id,
+    title: screening.attributes.movie.data.attributes.title,
+    movieId: screening.attributes.movie.data.id,
+    image: screening.attributes.movie.data.attributes.image.url,
+    ...screening.attributes,
+  };
+};
+
+const filterOldScreenings = (screenings, todaysDate) => {
+  const upcomingScreenings = screenings.filter((screening) => {
+    if (Date.parse(screening.start_time) > Date.parse(todaysDate)) {
+      return screening;
+    }
+  });
+  return upcomingScreenings;
+};
+
+const filterNextFiveDaysScreenings = (screenings, futureDate) => {
+  const filteredScreenings = screenings.filter((screening) => {
+    if (Date.parse(screening.start_time) < Date.parse(futureDate)) {
+      return screening;
+    }
+  });
+  return filteredScreenings;
+};
+
+const sortScreeningsByDate = (screenings) => {
+  const sortedScreenings = screenings.sort((a, b) => {
+    const keyA = new Date(a.start_time);
+    const keyB = new Date(b.start_time);
+    // Comparing the two dates
+    if (keyA < keyB) {
+      return -1;
+    }
+    if (keyA > keyB) {
+      return 1;
+    }
+    return 0;
+  });
+
+  return sortedScreenings;
+};
+
+const filterByUpomingScreenings = (arr, days) => {
+  const todaysDate = new Date();
+  const ms = new Date().getTime() + 86400000 * days;
+  const futureDate = new Date(ms);
+
+  const filteredByOldScreenings = filterOldScreenings(arr, todaysDate);
+
+  const filteredByFutureScreenings = filterNextFiveDaysScreenings(
+    filteredByOldScreenings,
+    futureDate
+  );
+
+  const sortedAndFilteredScreenings = sortScreeningsByDate(
+    filteredByFutureScreenings
+  );
+
+  return sortedAndFilteredScreenings.splice(0, 10);
+};
+
+const getUpcomingScreenings = async () => {
+  const dataBuff = await fetch(API_BASEURL);
+  const data = await dataBuff.json();
+  const screeningsData = await data.data;
+
+  const trimedData = screeningsData.map((screening) => trimData(screening));
+  return filterByUpomingScreenings(trimedData, 5);
+};
+
+export default getUpcomingScreenings;

--- a/src/screenings.js
+++ b/src/screenings.js
@@ -3,14 +3,17 @@ import fetch from 'node-fetch';
 const API_BASEURL =
   'https://lernia-kino-cms.herokuapp.com/api/screenings?populate=movie&pagination[pageSize]=1500';
 
-const trimData = (screening) => {
-  return {
-    id: screening.id,
-    title: screening.attributes.movie.data.attributes.title,
-    movieId: screening.attributes.movie.data.id,
-    image: screening.attributes.movie.data.attributes.image.url,
-    start_time: screening.attributes.start_time,
-  };
+export function trimData (screeningsArray) {
+  const trimmedArr = screeningsArray.map((screening) => {
+    return {
+      id: screening.id,
+      title: screening.attributes.movie.data.attributes.title,
+      movieId: screening.attributes.movie.data.id,
+      image: screening.attributes.movie.data.attributes.image.url,
+      start_time: screening.attributes.start_time,
+    };
+  });
+  return trimmedArr;
 };
 
 const filterOldScreenings = (screenings, todaysDate) => {
@@ -48,7 +51,7 @@ const sortScreeningsByDate = (screenings) => {
   return sortedScreenings;
 };
 
-const filterByUpomingScreenings = (arr, days) => {
+export const filterByUpomingScreenings = (arr, days) => {
   const todaysDate = new Date();
   const ms = new Date().getTime() + 86400000 * days;
   const futureDate = new Date(ms);
@@ -67,13 +70,12 @@ const filterByUpomingScreenings = (arr, days) => {
   return sortedAndFilteredScreenings.splice(0, 10);
 };
 
-const getUpcomingScreenings = async () => {
+export async function getUpcomingScreenings() {
   const dataBuff = await fetch(API_BASEURL);
   const data = await dataBuff.json();
   const screeningsData = await data.data;
 
-  const trimedData = screeningsData.map((screening) => trimData(screening));
-  return filterByUpomingScreenings(trimedData, 5);
+  const trimedData = trimData(screeningsData);
+  const filteredData = filterByUpomingScreenings(trimedData, 5);
+  return filteredData;
 };
-
-export default getUpcomingScreenings;

--- a/src/sections/_movieCards.scss
+++ b/src/sections/_movieCards.scss
@@ -1,3 +1,0 @@
-.movieCards{
-    background-color: yellow;
-}

--- a/src/sections/_screeningsCards.scss
+++ b/src/sections/_screeningsCards.scss
@@ -3,9 +3,12 @@
   flex-direction: row;
   justify-content: center;
   width: 100%;
+  padding: 1rem 0;
+
+  color: $c-white;
+  background-color: $c-black;
 
   .screeningsCardsLeft {
-    background-color: green;
     width: 40%;
 
     .screeningsListLeft {
@@ -14,7 +17,6 @@
   }
 
   .screeningsCardsRight {
-    background-color: blue;
     width: 40%;
 
     .screeningsListRight {
@@ -25,11 +27,12 @@
   .screeningCard {
     display: flex;
     flex-direction: row;
+    align-items: center;
   }
 
   .screeningCardMovieImage {
     height: 5rem;
-    width: 3rem;
+    width: 3.5rem;
     margin: 0.2rem 0.5rem;
 
     background-position: center;

--- a/src/sections/_screeningsCards.scss
+++ b/src/sections/_screeningsCards.scss
@@ -1,0 +1,3 @@
+.screeningsCards {
+  background-color: red;
+}

--- a/src/sections/_screeningsCards.scss
+++ b/src/sections/_screeningsCards.scss
@@ -1,3 +1,26 @@
 .screeningsCards {
+  display: flex;
+  flex-direction: row;
   background-color: red;
+  width: 100%;
+
+  .screeningsCardsLeft {
+    background-color: green;
+    width: 50%;
+    height: 20rem;
+
+    .screeningsListLeft {
+      width: 100%;
+    }
+  }
+
+  .screeningsCardsRight {
+    background-color: blue;
+    width: 50%;
+    height: 20rem;
+
+    .screeningsListRight {
+      width: 100%;
+    }
+  }
 }

--- a/src/sections/_screeningsCards.scss
+++ b/src/sections/_screeningsCards.scss
@@ -1,13 +1,12 @@
 .screeningsCards {
   display: flex;
   flex-direction: row;
-  background-color: red;
+  justify-content: center;
   width: 100%;
 
   .screeningsCardsLeft {
     background-color: green;
-    width: 50%;
-    height: 20rem;
+    width: 40%;
 
     .screeningsListLeft {
       width: 100%;
@@ -16,11 +15,24 @@
 
   .screeningsCardsRight {
     background-color: blue;
-    width: 50%;
-    height: 20rem;
+    width: 40%;
 
     .screeningsListRight {
       width: 100%;
     }
+  }
+
+  .screeningCard {
+    display: flex;
+    flex-direction: row;
+  }
+
+  .screeningCardMovieImage {
+    height: 5rem;
+    width: 3rem;
+    margin: 0.2rem 0.5rem;
+
+    background-position: center;
+    background-size: contain;
   }
 }

--- a/src/sections/_screeningsCards.scss
+++ b/src/sections/_screeningsCards.scss
@@ -9,7 +9,7 @@
   background-color: $c-black;
 
   .screeningsCardsLeft {
-    width: 40%;
+    width: 30%;
 
     .screeningsListLeft {
       width: 100%;
@@ -17,7 +17,7 @@
   }
 
   .screeningsCardsRight {
-    width: 40%;
+    width: 30%;
 
     .screeningsListRight {
       width: 100%;

--- a/src/sections/_screeningsCards.scss
+++ b/src/sections/_screeningsCards.scss
@@ -1,3 +1,9 @@
+.screeningsCardsHeader {
+  text-align: center;
+  color: $c-white;
+  background-color: $c-black;
+}
+
 .screeningsCards {
   display: flex;
   flex-direction: row;

--- a/static/main.css
+++ b/static/main.css
@@ -163,6 +163,12 @@ img {
   }
 }
 
+.screeningsCardsHeader {
+  text-align: center;
+  color: #fafafa;
+  background-color: #100f0f;
+}
+
 .screeningsCards {
   display: flex;
   flex-direction: row;

--- a/static/main.css
+++ b/static/main.css
@@ -168,16 +168,17 @@ img {
   flex-direction: row;
   justify-content: center;
   width: 100%;
+  padding: 1rem 0;
+  color: #fafafa;
+  background-color: #100f0f;
 }
 .screeningsCards .screeningsCardsLeft {
-  background-color: green;
   width: 40%;
 }
 .screeningsCards .screeningsCardsLeft .screeningsListLeft {
   width: 100%;
 }
 .screeningsCards .screeningsCardsRight {
-  background-color: blue;
   width: 40%;
 }
 .screeningsCards .screeningsCardsRight .screeningsListRight {
@@ -186,10 +187,11 @@ img {
 .screeningsCards .screeningCard {
   display: flex;
   flex-direction: row;
+  align-items: center;
 }
 .screeningsCards .screeningCardMovieImage {
   height: 5rem;
-  width: 3rem;
+  width: 3.5rem;
   margin: 0.2rem 0.5rem;
   background-position: center;
   background-size: contain;

--- a/static/main.css
+++ b/static/main.css
@@ -166,24 +166,33 @@ img {
 .screeningsCards {
   display: flex;
   flex-direction: row;
-  background-color: red;
+  justify-content: center;
   width: 100%;
 }
 .screeningsCards .screeningsCardsLeft {
   background-color: green;
-  width: 50%;
-  height: 20rem;
+  width: 40%;
 }
 .screeningsCards .screeningsCardsLeft .screeningsListLeft {
   width: 100%;
 }
 .screeningsCards .screeningsCardsRight {
   background-color: blue;
-  width: 50%;
-  height: 20rem;
+  width: 40%;
 }
 .screeningsCards .screeningsCardsRight .screeningsListRight {
   width: 100%;
+}
+.screeningsCards .screeningCard {
+  display: flex;
+  flex-direction: row;
+}
+.screeningsCards .screeningCardMovieImage {
+  height: 5rem;
+  width: 3rem;
+  margin: 0.2rem 0.5rem;
+  background-position: center;
+  background-size: contain;
 }
 
 .ftMovie .ftMovieContainer {

--- a/static/main.css
+++ b/static/main.css
@@ -173,13 +173,13 @@ img {
   background-color: #100f0f;
 }
 .screeningsCards .screeningsCardsLeft {
-  width: 40%;
+  width: 30%;
 }
 .screeningsCards .screeningsCardsLeft .screeningsListLeft {
   width: 100%;
 }
 .screeningsCards .screeningsCardsRight {
-  width: 40%;
+  width: 30%;
 }
 .screeningsCards .screeningsCardsRight .screeningsListRight {
   width: 100%;

--- a/static/main.css
+++ b/static/main.css
@@ -163,8 +163,8 @@ img {
   }
 }
 
-.movieCards {
-  background-color: yellow;
+.screeningsCards {
+  background-color: red;
 }
 
 .ftMovie .ftMovieContainer {

--- a/static/main.css
+++ b/static/main.css
@@ -164,7 +164,26 @@ img {
 }
 
 .screeningsCards {
+  display: flex;
+  flex-direction: row;
   background-color: red;
+  width: 100%;
+}
+.screeningsCards .screeningsCardsLeft {
+  background-color: green;
+  width: 50%;
+  height: 20rem;
+}
+.screeningsCards .screeningsCardsLeft .screeningsListLeft {
+  width: 100%;
+}
+.screeningsCards .screeningsCardsRight {
+  background-color: blue;
+  width: 50%;
+  height: 20rem;
+}
+.screeningsCards .screeningsCardsRight .screeningsListRight {
+  width: 100%;
 }
 
 .ftMovie .ftMovieContainer {

--- a/static/script.js
+++ b/static/script.js
@@ -78,10 +78,6 @@ const getUpcomingScreenings = async () => {
   return filterByUpomingScreenings(trimedData, 5);
 };
 
-const screeningsData = await getUpcomingScreenings();
-console.log(screeningsData);
-
-
 // Load movies data from API/DB
 const load = async() => {
   const url = 'data.json';
@@ -111,6 +107,9 @@ const loadEvents = async() => {
 const render = async () => {
   const data = await load()
   const eventsData = await loadEvents()
+
+  const screeningsData = await getUpcomingScreenings();
+  console.log(screeningsData);
 
   // console.log('EVENTS LOADED')
   // console.log(eventsData)
@@ -189,6 +188,59 @@ const render = async () => {
       eventLink.appendChild(eventContainer);
       eventsContainer.appendChild(eventLink);
   }
+
+  const screeningsContainer = document.querySelector('.screeningsCards');
+
+  const screeningsLeft = document.createElement('div');
+  screeningsLeft.classList.add('screeningsCardsLeft');
+  const screeningsListLeft = document.createElement('ul');
+  screeningsListLeft.classList.add('screeningsListLeft');
+
+  screeningsData.splice(5, 5).forEach((screening) => {
+    const startDate = screening.start_time.substring(10,0);
+    const startTime = screening.start_time.substring(11, 16)
+
+    const screeningCard = document.createElement('li');
+    screeningCard.classList.add('screeningCard');
+
+    const screeningCardMovieImage = document.createElement('div');
+    screeningCardMovieImage.classList.add('screeningCardMovieImage');
+    screeningCardMovieImage.style.backgroundImage = `url(${screening.image})`
+
+    const screeningCardInformation = document.createElement('div');
+    screeningCardInformation.classList.add('screeningCardInformation');
+
+    const screeningCardMovieTitle = document.createElement('p');
+    screeningCardMovieTitle.classList.add('screeningCardMovieTitle');
+    screeningCardMovieTitle.innerHTML = screening.title;
+
+    const screeningCardMovieRoom = document.createElement('p');
+    screeningCardMovieRoom.classList.add('screeningCardMovieRoom');
+    screeningCardMovieRoom.innerHTML = `Salong: ${screening.room}`;
+
+    const screeningCardMovieTime = document.createElement('p');
+    screeningCardMovieTime.classList.add('screeningCardMovieTime');
+    screeningCardMovieTime.innerHTML = `Tid: ${startDate} - ${startTime}`;
+
+    screeningCard.appendChild(screeningCardMovieImage);
+    screeningCardInformation.appendChild(screeningCardMovieTitle);
+    screeningCardInformation.appendChild(screeningCardMovieRoom);
+    screeningCardInformation.appendChild(screeningCardMovieTime);
+    screeningCard.appendChild(screeningCardInformation);
+    screeningsListLeft.appendChild(screeningCard);
+  })
+
+  const screeningsRight = document.createElement('div');
+  screeningsRight.classList.add('screeningsCardsRight');
+  const screeningsListRight = document.createElement('ul');
+  screeningsListRight.classList.add('screeningsListRight');
+
+
+  screeningsContainer.appendChild(screeningsLeft);
+  screeningsContainer.appendChild(screeningsRight);
+  screeningsLeft.appendChild(screeningsListLeft);
+  screeningsRight.appendChild(screeningsListRight);
+
 
   // console.log('MOVIES LOADED')
   // console.log(data)

--- a/static/script.js
+++ b/static/script.js
@@ -1,3 +1,4 @@
+
 console.log("Running..");
 
 // Load screenings from API
@@ -103,6 +104,19 @@ const loadEvents = async() => {
           console.log(error);
       }
 }
+
+const loadScreenings = async () => {
+  const url = '/screenings';
+  try {
+    const response = await fetch(url);
+    const data = await response.json();
+    console.log(data.data)
+  } catch (error) {
+    console.log(error)
+  }
+};
+
+loadScreenings();
 
 const createScreeningCards = (screening, screeningsListEl) => {
   const startDate = screening.start_time.substring(10,0);

--- a/static/script.js
+++ b/static/script.js
@@ -104,6 +104,40 @@ const loadEvents = async() => {
       }
 }
 
+const createScreeningCards = (screening, screeningsListEl) => {
+  const startDate = screening.start_time.substring(10,0);
+  const startTime = screening.start_time.substring(11, 16)
+
+  const screeningCard = document.createElement('li');
+  screeningCard.classList.add('screeningCard');
+
+  const screeningCardMovieImage = document.createElement('div');
+  screeningCardMovieImage.classList.add('screeningCardMovieImage');
+  screeningCardMovieImage.style.backgroundImage = `url(${screening.image})`
+
+  const screeningCardInformation = document.createElement('div');
+  screeningCardInformation.classList.add('screeningCardInformation');
+
+  const screeningCardMovieTitle = document.createElement('h3');
+  screeningCardMovieTitle.classList.add('screeningCardMovieTitle');
+  screeningCardMovieTitle.innerHTML = screening.title;
+
+  const screeningCardMovieRoom = document.createElement('p');
+  screeningCardMovieRoom.classList.add('screeningCardMovieRoom');
+  screeningCardMovieRoom.innerHTML = `Salong: ${screening.room}`;
+
+  const screeningCardMovieTime = document.createElement('p');
+  screeningCardMovieTime.classList.add('screeningCardMovieTime');
+  screeningCardMovieTime.innerHTML = `Tid: ${startDate} - ${startTime}`;
+
+  screeningCard.appendChild(screeningCardMovieImage);
+  screeningCardInformation.appendChild(screeningCardMovieTitle);
+  screeningCardInformation.appendChild(screeningCardMovieRoom);
+  screeningCardInformation.appendChild(screeningCardMovieTime);
+  screeningCard.appendChild(screeningCardInformation);
+  screeningsListEl.appendChild(screeningCard);
+}
+
 const render = async () => {
   const data = await load()
   const eventsData = await loadEvents()
@@ -196,45 +230,18 @@ const render = async () => {
   const screeningsListLeft = document.createElement('ul');
   screeningsListLeft.classList.add('screeningsListLeft');
 
-  screeningsData.splice(5, 5).forEach((screening) => {
-    const startDate = screening.start_time.substring(10,0);
-    const startTime = screening.start_time.substring(11, 16)
-
-    const screeningCard = document.createElement('li');
-    screeningCard.classList.add('screeningCard');
-
-    const screeningCardMovieImage = document.createElement('div');
-    screeningCardMovieImage.classList.add('screeningCardMovieImage');
-    screeningCardMovieImage.style.backgroundImage = `url(${screening.image})`
-
-    const screeningCardInformation = document.createElement('div');
-    screeningCardInformation.classList.add('screeningCardInformation');
-
-    const screeningCardMovieTitle = document.createElement('h3');
-    screeningCardMovieTitle.classList.add('screeningCardMovieTitle');
-    screeningCardMovieTitle.innerHTML = screening.title;
-
-    const screeningCardMovieRoom = document.createElement('p');
-    screeningCardMovieRoom.classList.add('screeningCardMovieRoom');
-    screeningCardMovieRoom.innerHTML = `Salong: ${screening.room}`;
-
-    const screeningCardMovieTime = document.createElement('p');
-    screeningCardMovieTime.classList.add('screeningCardMovieTime');
-    screeningCardMovieTime.innerHTML = `Tid: ${startDate} - ${startTime}`;
-
-    screeningCard.appendChild(screeningCardMovieImage);
-    screeningCardInformation.appendChild(screeningCardMovieTitle);
-    screeningCardInformation.appendChild(screeningCardMovieRoom);
-    screeningCardInformation.appendChild(screeningCardMovieTime);
-    screeningCard.appendChild(screeningCardInformation);
-    screeningsListLeft.appendChild(screeningCard);
+  screeningsData.splice(0, 5).forEach((screening) => {
+    createScreeningCards(screening, screeningsListLeft);
   });
 
-  const screeningsRight = document.createElement('div');
+    const screeningsRight = document.createElement('div');
   screeningsRight.classList.add('screeningsCardsRight');
   const screeningsListRight = document.createElement('ul');
   screeningsListRight.classList.add('screeningsListRight');
 
+  screeningsData.forEach((screening) => {
+    createScreeningCards(screening, screeningsListRight)
+  });
 
   screeningsContainer.appendChild(screeningsLeft);
   screeningsContainer.appendChild(screeningsRight);

--- a/static/script.js
+++ b/static/script.js
@@ -1,83 +1,4 @@
-
 console.log("Running..");
-
-// Load screenings from API
-const API_BASEURL =
-  'https://lernia-kino-cms.herokuapp.com/api/screenings?populate=movie';
-
-const trimData = (screening) => {
-  return {
-    id: screening.id,
-    title: screening.attributes.movie.data.attributes.title,
-    movieId: screening.attributes.movie.data.id,
-    image: screening.attributes.movie.data.attributes.image.url,
-    ...screening.attributes,
-  };
-};
-
-const filterOldScreenings = (screenings, todaysDate) => {
-  const upcomingScreenings = screenings.filter((screening) => {
-    if (Date.parse(screening.start_time) > Date.parse(todaysDate)) {
-      return screening;
-    }
-  });
-  return upcomingScreenings;
-};
-
-const filterNextFiveDaysScreenings = (screenings, futureDate) => {
-  const filteredScreenings = screenings.filter((screening) => {
-    if (Date.parse(screening.start_time) < Date.parse(futureDate)) {
-      return screening;
-    }
-  });
-  return filteredScreenings;
-};
-
-const sortScreeningsByDate = (screenings) => {
-  const sortedScreenings = screenings.sort((a, b) => {
-    const keyA = new Date(a.start_time);
-    const keyB = new Date(b.start_time);
-    // Comparing the two dates
-    if (keyA < keyB) {
-      return -1;
-    }
-    if (keyA > keyB) {
-      return 1;
-    }
-    return 0;
-  });
-
-  return sortedScreenings;
-};
-
-const filterByUpomingScreenings = (arr, days) => {
-  const todaysDate = new Date();
-  const ms = new Date().getTime() + 86400000 * days;
-  const futureDate = new Date(ms);
-
-  const filteredByOldScreenings = filterOldScreenings(arr, todaysDate);
-
-  const filteredByFutureScreenings = filterNextFiveDaysScreenings(
-    filteredByOldScreenings,
-    futureDate
-  );
-
-  const sortedAndFilteredScreenings = sortScreeningsByDate(
-    filteredByFutureScreenings
-  );
-
-  return sortedAndFilteredScreenings.splice(0, 10);
-};
-
-const getUpcomingScreenings = async () => {
-  const dataBuff = await fetch(API_BASEURL);
-  const data = await dataBuff.json();
-  const screeningsData = await data.data;
-
-
-  const trimedData = screeningsData.map((screening) => trimData(screening));
-  return filterByUpomingScreenings(trimedData, 5);
-};
 
 // Load movies data from API/DB
 const load = async() => {
@@ -110,7 +31,7 @@ const loadScreenings = async () => {
   try {
     const response = await fetch(url);
     const data = await response.json();
-    console.log(data.data)
+    return data.data;
   } catch (error) {
     console.log(error)
   }
@@ -155,9 +76,7 @@ const createScreeningCards = (screening, screeningsListEl) => {
 const render = async () => {
   const data = await load()
   const eventsData = await loadEvents()
-
-  const screeningsData = await getUpcomingScreenings();
-  console.log(screeningsData);
+  const screeningsData = await loadScreenings();
 
   // console.log('EVENTS LOADED')
   // console.log(eventsData)

--- a/static/script.js
+++ b/static/script.js
@@ -28,7 +28,7 @@ const loadEvents = async() => {
 
 // Load screenings data from API
 const loadScreenings = async () => {
-  const url = '/screenings';
+  const url = '/api/screenings';
   try {
     const response = await fetch(url);
     const data = await response.json();
@@ -47,7 +47,7 @@ const createScreeningCards = (screening, screeningsListEl) => {
 
   const screeningCard = document.createElement('a');
   screeningCard.classList.add('screeningCard');
-  screeningCard.href = '#';
+  screeningCard.href = `/movies/${screening.movieId}`;
 
   const screeningCardMovieImage = document.createElement('div');
   screeningCardMovieImage.classList.add('screeningCardMovieImage');

--- a/static/script.js
+++ b/static/script.js
@@ -26,6 +26,7 @@ const loadEvents = async() => {
       }
 }
 
+// Load screenings data from API
 const loadScreenings = async () => {
   const url = '/screenings';
   try {
@@ -37,14 +38,16 @@ const loadScreenings = async () => {
   }
 };
 
-loadScreenings();
-
 const createScreeningCards = (screening, screeningsListEl) => {
   const startDate = screening.start_time.substring(10,0);
   const startTime = screening.start_time.substring(11, 16)
 
-  const screeningCard = document.createElement('li');
+  const screeningCardContainer = document.createElement('li');
+  screeningCardContainer.classList.add('screeningCardContainer');
+
+  const screeningCard = document.createElement('a');
   screeningCard.classList.add('screeningCard');
+  screeningCard.href = '#';
 
   const screeningCardMovieImage = document.createElement('div');
   screeningCardMovieImage.classList.add('screeningCardMovieImage');
@@ -70,7 +73,8 @@ const createScreeningCards = (screening, screeningsListEl) => {
   screeningCardInformation.appendChild(screeningCardMovieRoom);
   screeningCardInformation.appendChild(screeningCardMovieTime);
   screeningCard.appendChild(screeningCardInformation);
-  screeningsListEl.appendChild(screeningCard);
+  screeningCardContainer.appendChild(screeningCard);
+  screeningsListEl.appendChild(screeningCardContainer);
 }
 
 const render = async () => {

--- a/static/script.js
+++ b/static/script.js
@@ -210,7 +210,7 @@ const render = async () => {
     const screeningCardInformation = document.createElement('div');
     screeningCardInformation.classList.add('screeningCardInformation');
 
-    const screeningCardMovieTitle = document.createElement('p');
+    const screeningCardMovieTitle = document.createElement('h3');
     screeningCardMovieTitle.classList.add('screeningCardMovieTitle');
     screeningCardMovieTitle.innerHTML = screening.title;
 
@@ -228,7 +228,7 @@ const render = async () => {
     screeningCardInformation.appendChild(screeningCardMovieTime);
     screeningCard.appendChild(screeningCardInformation);
     screeningsListLeft.appendChild(screeningCard);
-  })
+  });
 
   const screeningsRight = document.createElement('div');
   screeningsRight.classList.add('screeningsCardsRight');

--- a/templates/index.handlebars
+++ b/templates/index.handlebars
@@ -1,54 +1,52 @@
- <div class="hero">
-        <div class="heroContainer">
-          <a class="heroPicPrev">&#10094;</a>
-          <a class="heroPicNext">&#10095;</a>
-        </div>
-      </div>
-      <div class="aboutCovid">
-        <h2>IMPORTANT COVID-19 INFO</h2>
-        <p>Om det är fler än 20 deltagare får det enbart vara sittande deltagare
-          (gäller tillställningar inomhus). Om vaccinationsbevis används gäller
-          detta för allmänna sammankomster och offentliga tillställningar
-          inomhus upp till 500 personer. Om det är fler än 20 och högst 500
-          deltagare inomhus utan vaccinationsbevis gäller krav på maximalt 8
-          personer per sällskap och 1 meters avstånd mellan sällskapen. Vid
-          arrangemang större än 500 deltagare inomhus krävs vaccinationsbevis
-          samt maximalt 8 personer per sällskap och 1 meters avstånd mellan
-          sällskapen. I föreskriften om de aktuella åtgärderna finns särskilda
-          anvisningar i samband med religionsutövning. Dessutom finns
-          föreskrifter om ytterligare smittskyddsåtgärder som ska vidtas så som
-          att erbjuda möjlighet till handtvätt, och informera om hur
-          smittspridning kan undvikas.</p></div>
-      <div class="comingSoon">
-        <h2>KOMMANDE FILMER</h2>
-        <div class="comingSoonImg">
-          <img src="img/covers/cover10.jpg" alt="" />
-        </div>
-        <div class="comingSoonText">
-          <a href="/movies">Alla kommande</a>
-        </div>
-      </div>
-      <div class="screeningsCards"></div>
-      <div class="ftMovie">
-        <div class="ftMovieContainer">
-          <div class="ftMovieLayer">
-            <h2 class="ftMovieHeader">VECKANS FILM I FOKUS</h2>
-            <div class="ftMovieDescription">Lorem ipsum dolor sit amet
-              consectetur, adipisicing elit. Tempora a beatae atque ullam
-              excepturi iure.</div>
-            <a class="ftMovieButton" href="">Mer information</a>
-          </div>
-        </div>
-      </div>
-      <div class="events">
-        <div class="eventsHeaderContainer">
-          <h2 class="eventsHeader">KOMMANDE EVENTS</h2>
-          <div>
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-            eiusmod tempor incididunt ut labore et dolore magna aliqua. Lorem
-            ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
-            tempor.
-          </div>
-        </div>
-        <div class="eventsContainer"></div>
-      </div>
+<div class='hero'>
+  <div class='heroContainer'>
+    <a class='heroPicPrev'>&#10094;</a>
+    <a class='heroPicNext'>&#10095;</a>
+  </div>
+</div>
+<div class='aboutCovid'>
+  <h2>IMPORTANT COVID-19 INFO</h2>
+  <p>Om det är fler än 20 deltagare får det enbart vara sittande deltagare
+    (gäller tillställningar inomhus). Om vaccinationsbevis används gäller detta
+    för allmänna sammankomster och offentliga tillställningar inomhus upp till
+    500 personer. Om det är fler än 20 och högst 500 deltagare inomhus utan
+    vaccinationsbevis gäller krav på maximalt 8 personer per sällskap och 1
+    meters avstånd mellan sällskapen. Vid arrangemang större än 500 deltagare
+    inomhus krävs vaccinationsbevis samt maximalt 8 personer per sällskap och 1
+    meters avstånd mellan sällskapen. I föreskriften om de aktuella åtgärderna
+    finns särskilda anvisningar i samband med religionsutövning. Dessutom finns
+    föreskrifter om ytterligare smittskyddsåtgärder som ska vidtas så som att
+    erbjuda möjlighet till handtvätt, och informera om hur smittspridning kan
+    undvikas.</p></div>
+<div class='comingSoon'>
+  <h2>KOMMANDE FILMER</h2>
+  <div class='comingSoonImg'>
+    <img src='img/covers/cover10.jpg' alt='' />
+  </div>
+  <div class='comingSoonText'>
+    <a href='/movies'>Alla kommande</a>
+  </div>
+</div>
+<h2 class='screeningsCardsHeader'>Kommande visningar:</h2>
+<div class='screeningsCards'></div>
+<div class='ftMovie'>
+  <div class='ftMovieContainer'>
+    <div class='ftMovieLayer'>
+      <h2 class='ftMovieHeader'>VECKANS FILM I FOKUS</h2>
+      <div class='ftMovieDescription'>Lorem ipsum dolor sit amet consectetur,
+        adipisicing elit. Tempora a beatae atque ullam excepturi iure.</div>
+      <a class='ftMovieButton' href=''>Mer information</a>
+    </div>
+  </div>
+</div>
+<div class='events'>
+  <div class='eventsHeaderContainer'>
+    <h2 class='eventsHeader'>KOMMANDE EVENTS</h2>
+    <div>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+      tempor incididunt ut labore et dolore magna aliqua. Lorem ipsum dolor sit
+      amet, consectetur adipiscing elit, sed do eiusmod tempor.
+    </div>
+  </div>
+  <div class='eventsContainer'></div>
+</div>

--- a/templates/index.handlebars
+++ b/templates/index.handlebars
@@ -28,7 +28,7 @@
           <a href="/movies">Alla kommande</a>
         </div>
       </div>
-      <div class="screeningsCards">screeningsCards</div>
+      <div class="screeningsCards"></div>
       <div class="ftMovie">
         <div class="ftMovieContainer">
           <div class="ftMovieLayer">

--- a/templates/index.handlebars
+++ b/templates/index.handlebars
@@ -50,3 +50,4 @@
   </div>
   <div class='eventsContainer'></div>
 </div>
+    <script type="module" src="/script.js"></script>

--- a/templates/index.handlebars
+++ b/templates/index.handlebars
@@ -28,7 +28,7 @@
           <a href="/movies">Alla kommande</a>
         </div>
       </div>
-      <div class="movieCards">movieCards</div>
+      <div class="screeningsCards">screeningsCards</div>
       <div class="ftMovie">
         <div class="ftMovieContainer">
           <div class="ftMovieLayer">

--- a/templates/layouts/main.handlebars
+++ b/templates/layouts/main.handlebars
@@ -51,6 +51,5 @@
       src="https://kit.fontawesome.com/07a95dbd5e.js"
       crossorigin="anonymous"
     ></script>
-    <script type="module" src="script.js"></script>
   </body>
 </html>

--- a/tests/screenings.spec.js
+++ b/tests/screenings.spec.js
@@ -1,10 +1,10 @@
-import {jest} from '@jest/globals'
-import { trimData } from '../src/screenings.js'
+import { jest } from '@jest/globals';
+import { trimData, filterOldScreenings } from '../src/screenings.js';
 
 // Mock Date
 beforeEach(() => {
   jest.useFakeTimers();
-  jest.setSystemTime(new Date(2022, 0, 27).getTime())
+  jest.setSystemTime(new Date(2022, 0, 27).getTime());
 });
 
 afterEach(() => {
@@ -16,2019 +16,2105 @@ test('If array gets trimmed down to id, title, start_time, movieId, room and ima
   const trimmedDataArray = await trimData(screeningsArray);
 
   trimmedDataArray.forEach((screening) => {
-      expect(screening.id).toBeTruthy();
-      expect(screening.title).toBeTruthy();
-      expect(screening.start_time).toBeTruthy();
-      expect(screening.movieId).toBeTruthy();
-      expect(screening.image).toBeTruthy();
-      expect(screening.room).toBeTruthy();
-    });
+    expect(screening.id).toBeTruthy();
+    expect(screening.title).toBeTruthy();
+    expect(screening.start_time).toBeTruthy();
+    expect(screening.movieId).toBeTruthy();
+    expect(screening.image).toBeTruthy();
+    expect(screening.room).toBeTruthy();
   });
+});
 
+test('If old screenings are removed from array', async () => {
+  const date = new Date();
+  const screeningsArray = await trimData(data);
+  const filteredScreenings = filterOldScreenings(screeningsArray, date);
 
-
-
+  filteredScreenings.forEach((screening) => {
+    expect(Date.parse(screening.start_time) > Date.parse(date));
+  });
+});
 
 // MOCK data
 const data = [
-      {
-          "id": 1,
-          "attributes": {
-              "start_time": "2022-01-24T12:00:00.000Z",
-              "room": "Stora salongen",
-              "createdAt": "2022-01-23T10:31:58.536Z",
-              "updatedAt": "2022-01-23T10:31:58.536Z",
-              "movie": {
-                  "data": {
-                      "id": 10,
-                      "attributes": {
-                          "title": "Threat Level Midnight: The Movie",
-                          "imdbId": "tt11620828",
-                          "intro": "After secret agent **Michael Scarn** (played by Steve Carell) is forced into retirement due to the death of his wife **Catherine Zeta-Scarn**, the President of the United States of America (played by Craig Robinson) requests that he prevents **Goldenface** (played by John Krasinski) from blowing up the NHL All-Star Game and killing several hostages.\n\nSee more info [on IMDB](https://imdb.com/title/tt11620828)",
-                          "image": {
-                              "url": "https://m.media-amazon.com/images/M/MV5BZjMzNzE4ZGItMDI5Zi00ZjE3LThkODctYTlhZWY1ZTdmMGNjXkEyXkFqcGdeQXVyOTExNzM4NDM@._V1_.jpg"
-                          },
-                          "createdAt": "2022-01-17T10:51:45.145Z",
-                          "updatedAt": "2022-01-18T08:47:13.309Z",
-                          "publishedAt": "2022-01-17T10:51:53.355Z"
-                      }
-                  }
-              }
-          }
-      },
-      {
-          "id": 2,
-          "attributes": {
-              "start_time": "2022-01-24T17:00:00.000Z",
-              "room": "Stora salongen",
-              "createdAt": "2022-01-23T10:31:59.065Z",
-              "updatedAt": "2022-01-23T10:31:59.065Z",
-              "movie": {
-                  "data": {
-                      "id": 8,
-                      "attributes": {
-                          "title": "Idiocracy",
-                          "imdbId": "tt0387808",
-                          "intro": "Private **Joe Bauers**, a decisively average American, is selected as a guinea pig for a top-secret hibernation program but is forgotten, awakening to a future so incredibly moronic he's easily the most intelligent person alive.\n\nSee more info [on IMDB](https://imdb.com/title/tt0387808)",
-                          "image": {
-                              "url": "https://m.media-amazon.com/images/M/MV5BMWQ4MzI2ZDQtYjk3MS00ODdjLTkwN2QtOTBjYzIwM2RmNzgyXkEyXkFqcGdeQXVyMTQxNzMzNDI@._V1_.jpg"
-                          },
-                          "createdAt": "2022-01-17T09:32:08.570Z",
-                          "updatedAt": "2022-01-18T08:48:02.876Z",
-                          "publishedAt": "2022-01-17T09:32:12.868Z"
-                      }
-                  }
-              }
-          }
-      },
-      {
-          "id": 3,
-          "attributes": {
-              "start_time": "2022-01-24T19:00:00.000Z",
-              "room": "Stora salongen",
-              "createdAt": "2022-01-23T10:31:59.612Z",
-              "updatedAt": "2022-01-23T10:31:59.612Z",
-              "movie": {
-                  "data": {
-                      "id": 5,
-                      "attributes": {
-                          "title": "12 Angry Men",
-                          "imdbId": "tt0050083",
-                          "intro": "The jury in a New York City murder trial is frustrated by a single member whose skeptical caution forces them to more carefully consider the evidence before jumping to a hasty verdict.\n\nSee more info [on IMDB](https://imdb.com/title/tt0050083)",
-                          "image": {
-                              "url": "https://m.media-amazon.com/images/M/MV5BMWU4N2FjNzYtNTVkNC00NzQ0LTg0MjAtYTJlMjFhNGUxZDFmXkEyXkFqcGdeQXVyNjc1NTYyMjg@._V1_.jpg"
-                          },
-                          "createdAt": "2022-01-17T05:01:21.807Z",
-                          "updatedAt": "2022-01-18T08:48:15.429Z",
-                          "publishedAt": "2022-01-17T05:01:24.036Z"
-                      }
-                  }
-              }
-          }
-      },
-      {
-          "id": 4,
-          "attributes": {
-              "start_time": "2022-01-24T21:00:00.000Z",
-              "room": "Stora salongen",
-              "createdAt": "2022-01-23T10:32:00.277Z",
-              "updatedAt": "2022-01-23T10:32:00.277Z",
-              "movie": {
-                  "data": {
-                      "id": 5,
-                      "attributes": {
-                          "title": "12 Angry Men",
-                          "imdbId": "tt0050083",
-                          "intro": "The jury in a New York City murder trial is frustrated by a single member whose skeptical caution forces them to more carefully consider the evidence before jumping to a hasty verdict.\n\nSee more info [on IMDB](https://imdb.com/title/tt0050083)",
-                          "image": {
-                              "url": "https://m.media-amazon.com/images/M/MV5BMWU4N2FjNzYtNTVkNC00NzQ0LTg0MjAtYTJlMjFhNGUxZDFmXkEyXkFqcGdeQXVyNjc1NTYyMjg@._V1_.jpg"
-                          },
-                          "createdAt": "2022-01-17T05:01:21.807Z",
-                          "updatedAt": "2022-01-18T08:48:15.429Z",
-                          "publishedAt": "2022-01-17T05:01:24.036Z"
-                      }
-                  }
-              }
-          }
-      },
-      {
-          "id": 5,
-          "attributes": {
-              "start_time": "2022-01-25T12:00:00.000Z",
-              "room": "Stora salongen",
-              "createdAt": "2022-01-23T10:32:00.822Z",
-              "updatedAt": "2022-01-23T10:32:00.822Z",
-              "movie": {
-                  "data": {
-                      "id": 3,
-                      "attributes": {
-                          "title": "The Godfather: Part II",
-                          "imdbId": "tt0071562",
-                          "intro": "The early life and career of **Vito Corleone** in 1920s New York City is portrayed, while his son, **Michael**, expands and tightens his grip on the family crime syndicate.\n\nSee more info [on IMDB](https://imdb.com/title/tt0071562)",
-                          "image": {
-                              "url": "https://m.media-amazon.com/images/M/MV5BMWMwMGQzZTItY2JlNC00OWZiLWIyMDctNDk2ZDQ2YjRjMWQ0XkEyXkFqcGdeQXVyNzkwMjQ5NzM@._V1_.jpg"
-                          },
-                          "createdAt": "2022-01-17T05:00:31.562Z",
-                          "updatedAt": "2022-01-18T08:46:47.388Z",
-                          "publishedAt": "2022-01-17T05:00:33.453Z"
-                      }
-                  }
-              }
-          }
-      },
-      {
-          "id": 6,
-          "attributes": {
-              "start_time": "2022-01-25T17:00:00.000Z",
-              "room": "Stora salongen",
-              "createdAt": "2022-01-23T10:32:01.366Z",
-              "updatedAt": "2022-01-23T10:32:01.366Z",
-              "movie": {
-                  "data": {
-                      "id": 3,
-                      "attributes": {
-                          "title": "The Godfather: Part II",
-                          "imdbId": "tt0071562",
-                          "intro": "The early life and career of **Vito Corleone** in 1920s New York City is portrayed, while his son, **Michael**, expands and tightens his grip on the family crime syndicate.\n\nSee more info [on IMDB](https://imdb.com/title/tt0071562)",
-                          "image": {
-                              "url": "https://m.media-amazon.com/images/M/MV5BMWMwMGQzZTItY2JlNC00OWZiLWIyMDctNDk2ZDQ2YjRjMWQ0XkEyXkFqcGdeQXVyNzkwMjQ5NzM@._V1_.jpg"
-                          },
-                          "createdAt": "2022-01-17T05:00:31.562Z",
-                          "updatedAt": "2022-01-18T08:46:47.388Z",
-                          "publishedAt": "2022-01-17T05:00:33.453Z"
-                      }
-                  }
-              }
-          }
-      },
-      {
-          "id": 7,
-          "attributes": {
-              "start_time": "2022-01-25T19:00:00.000Z",
-              "room": "Stora salongen",
-              "createdAt": "2022-01-23T10:32:01.931Z",
-              "updatedAt": "2022-01-23T10:32:01.931Z",
-              "movie": {
-                  "data": {
-                      "id": 10,
-                      "attributes": {
-                          "title": "Threat Level Midnight: The Movie",
-                          "imdbId": "tt11620828",
-                          "intro": "After secret agent **Michael Scarn** (played by Steve Carell) is forced into retirement due to the death of his wife **Catherine Zeta-Scarn**, the President of the United States of America (played by Craig Robinson) requests that he prevents **Goldenface** (played by John Krasinski) from blowing up the NHL All-Star Game and killing several hostages.\n\nSee more info [on IMDB](https://imdb.com/title/tt11620828)",
-                          "image": {
-                              "url": "https://m.media-amazon.com/images/M/MV5BZjMzNzE4ZGItMDI5Zi00ZjE3LThkODctYTlhZWY1ZTdmMGNjXkEyXkFqcGdeQXVyOTExNzM4NDM@._V1_.jpg"
-                          },
-                          "createdAt": "2022-01-17T10:51:45.145Z",
-                          "updatedAt": "2022-01-18T08:47:13.309Z",
-                          "publishedAt": "2022-01-17T10:51:53.355Z"
-                      }
-                  }
-              }
-          }
-      },
-      {
-          "id": 8,
-          "attributes": {
-              "start_time": "2022-01-25T21:00:00.000Z",
-              "room": "Stora salongen",
-              "createdAt": "2022-01-23T10:32:02.611Z",
-              "updatedAt": "2022-01-23T10:32:02.611Z",
-              "movie": {
-                  "data": {
-                      "id": 1,
-                      "attributes": {
-                          "title": "The Shawshank Redemption",
-                          "imdbId": "tt0111161",
-                          "intro": "Two imprisoned men bond over a number of years, finding solace and eventual redemption through acts of common decency.\n\nSee more info [on IMDB](https://imdb.com/title/tt0111161)",
-                          "image": {
-                              "url": "https://m.media-amazon.com/images/M/MV5BMDFkYTc0MGEtZmNhMC00ZDIzLWFmNTEtODM1ZmRlYWMwMWFmXkEyXkFqcGdeQXVyMTMxODk2OTU@._V1_.jpg"
-                          },
-                          "createdAt": "2022-01-17T04:59:14.315Z",
-                          "updatedAt": "2022-01-18T08:47:01.417Z",
-                          "publishedAt": "2022-01-17T04:59:16.846Z"
-                      }
-                  }
-              }
-          }
-      },
-      {
-          "id": 9,
-          "attributes": {
-              "start_time": "2022-01-26T12:00:00.000Z",
-              "room": "Stora salongen",
-              "createdAt": "2022-01-23T10:32:03.180Z",
-              "updatedAt": "2022-01-23T10:32:03.180Z",
-              "movie": {
-                  "data": {
-                      "id": 5,
-                      "attributes": {
-                          "title": "12 Angry Men",
-                          "imdbId": "tt0050083",
-                          "intro": "The jury in a New York City murder trial is frustrated by a single member whose skeptical caution forces them to more carefully consider the evidence before jumping to a hasty verdict.\n\nSee more info [on IMDB](https://imdb.com/title/tt0050083)",
-                          "image": {
-                              "url": "https://m.media-amazon.com/images/M/MV5BMWU4N2FjNzYtNTVkNC00NzQ0LTg0MjAtYTJlMjFhNGUxZDFmXkEyXkFqcGdeQXVyNjc1NTYyMjg@._V1_.jpg"
-                          },
-                          "createdAt": "2022-01-17T05:01:21.807Z",
-                          "updatedAt": "2022-01-18T08:48:15.429Z",
-                          "publishedAt": "2022-01-17T05:01:24.036Z"
-                      }
-                  }
-              }
-          }
-      },
-      {
-          "id": 10,
-          "attributes": {
-              "start_time": "2022-01-26T17:00:00.000Z",
-              "room": "Stora salongen",
-              "createdAt": "2022-01-23T10:32:03.768Z",
-              "updatedAt": "2022-01-23T10:32:03.768Z",
-              "movie": {
-                  "data": {
-                      "id": 3,
-                      "attributes": {
-                          "title": "The Godfather: Part II",
-                          "imdbId": "tt0071562",
-                          "intro": "The early life and career of **Vito Corleone** in 1920s New York City is portrayed, while his son, **Michael**, expands and tightens his grip on the family crime syndicate.\n\nSee more info [on IMDB](https://imdb.com/title/tt0071562)",
-                          "image": {
-                              "url": "https://m.media-amazon.com/images/M/MV5BMWMwMGQzZTItY2JlNC00OWZiLWIyMDctNDk2ZDQ2YjRjMWQ0XkEyXkFqcGdeQXVyNzkwMjQ5NzM@._V1_.jpg"
-                          },
-                          "createdAt": "2022-01-17T05:00:31.562Z",
-                          "updatedAt": "2022-01-18T08:46:47.388Z",
-                          "publishedAt": "2022-01-17T05:00:33.453Z"
-                      }
-                  }
-              }
-          }
-      },
-      {
-          "id": 11,
-          "attributes": {
-              "start_time": "2022-01-26T19:00:00.000Z",
-              "room": "Stora salongen",
-              "createdAt": "2022-01-23T10:32:04.326Z",
-              "updatedAt": "2022-01-23T10:32:04.326Z",
-              "movie": {
-                  "data": {
-                      "id": 10,
-                      "attributes": {
-                          "title": "Threat Level Midnight: The Movie",
-                          "imdbId": "tt11620828",
-                          "intro": "After secret agent **Michael Scarn** (played by Steve Carell) is forced into retirement due to the death of his wife **Catherine Zeta-Scarn**, the President of the United States of America (played by Craig Robinson) requests that he prevents **Goldenface** (played by John Krasinski) from blowing up the NHL All-Star Game and killing several hostages.\n\nSee more info [on IMDB](https://imdb.com/title/tt11620828)",
-                          "image": {
-                              "url": "https://m.media-amazon.com/images/M/MV5BZjMzNzE4ZGItMDI5Zi00ZjE3LThkODctYTlhZWY1ZTdmMGNjXkEyXkFqcGdeQXVyOTExNzM4NDM@._V1_.jpg"
-                          },
-                          "createdAt": "2022-01-17T10:51:45.145Z",
-                          "updatedAt": "2022-01-18T08:47:13.309Z",
-                          "publishedAt": "2022-01-17T10:51:53.355Z"
-                      }
-                  }
-              }
-          }
-      },
-      {
-          "id": 12,
-          "attributes": {
-              "start_time": "2022-01-26T21:00:00.000Z",
-              "room": "Stora salongen",
-              "createdAt": "2022-01-23T10:32:05.168Z",
-              "updatedAt": "2022-01-23T10:32:05.168Z",
-              "movie": {
-                  "data": {
-                      "id": 2,
-                      "attributes": {
-                          "title": "The Godfather",
-                          "imdbId": "tt0068646",
-                          "intro": "The Godfather follows **Vito Corleone**, Don of the Corleone family, as he passes the mantel to his unwilling son, **Michael**.\n\nSee more info [on IMDB](https://imdb.com/title/tt0068646)",
-                          "image": {
-                              "url": "https://m.media-amazon.com/images/M/MV5BM2MyNjYxNmUtYTAwNi00MTYxLWJmNWYtYzZlODY3ZTk3OTFlXkEyXkFqcGdeQXVyNzkwMjQ5NzM@._V1_.jpg"
-                          },
-                          "createdAt": "2022-01-17T04:59:42.763Z",
-                          "updatedAt": "2022-01-18T08:47:25.840Z",
-                          "publishedAt": "2022-01-17T04:59:44.929Z"
-                      }
-                  }
-              }
-          }
-      },
-      {
-          "id": 13,
-          "attributes": {
-              "start_time": "2022-01-27T12:00:00.000Z",
-              "room": "Stora salongen",
-              "createdAt": "2022-01-23T10:32:05.701Z",
-              "updatedAt": "2022-01-23T10:32:05.701Z",
-              "movie": {
-                  "data": {
-                      "id": 4,
-                      "attributes": {
-                          "title": "The Dark Knight",
-                          "imdbId": "tt0468569",
-                          "intro": "When the menace known as the Joker wreaks havoc and chaos on the people of Gotham, **Batman** must accept one of the greatest psychological and physical tests of his ability to fight injustice.\n\nSee more info [on IMDB](https://imdb.com/title/tt0468569)",
-                          "image": {
-                              "url": "https://m.media-amazon.com/images/M/MV5BMTMxNTMwODM0NF5BMl5BanBnXkFtZTcwODAyMTk2Mw@@._V1_.jpg"
-                          },
-                          "createdAt": "2022-01-17T05:00:58.423Z",
-                          "updatedAt": "2022-01-18T08:47:52.866Z",
-                          "publishedAt": "2022-01-17T05:01:00.594Z"
-                      }
-                  }
-              }
-          }
-      },
-      {
-          "id": 14,
-          "attributes": {
-              "start_time": "2022-01-27T17:00:00.000Z",
-              "room": "Stora salongen",
-              "createdAt": "2022-01-23T10:32:06.233Z",
-              "updatedAt": "2022-01-23T10:32:06.233Z",
-              "movie": {
-                  "data": {
-                      "id": 8,
-                      "attributes": {
-                          "title": "Idiocracy",
-                          "imdbId": "tt0387808",
-                          "intro": "Private **Joe Bauers**, a decisively average American, is selected as a guinea pig for a top-secret hibernation program but is forgotten, awakening to a future so incredibly moronic he's easily the most intelligent person alive.\n\nSee more info [on IMDB](https://imdb.com/title/tt0387808)",
-                          "image": {
-                              "url": "https://m.media-amazon.com/images/M/MV5BMWQ4MzI2ZDQtYjk3MS00ODdjLTkwN2QtOTBjYzIwM2RmNzgyXkEyXkFqcGdeQXVyMTQxNzMzNDI@._V1_.jpg"
-                          },
-                          "createdAt": "2022-01-17T09:32:08.570Z",
-                          "updatedAt": "2022-01-18T08:48:02.876Z",
-                          "publishedAt": "2022-01-17T09:32:12.868Z"
-                      }
-                  }
-              }
-          }
-      },
-      {
-          "id": 15,
-          "attributes": {
-              "start_time": "2022-01-27T19:00:00.000Z",
-              "room": "Stora salongen",
-              "createdAt": "2022-01-23T10:32:06.896Z",
-              "updatedAt": "2022-01-23T10:32:06.896Z",
-              "movie": {
-                  "data": {
-                      "id": 5,
-                      "attributes": {
-                          "title": "12 Angry Men",
-                          "imdbId": "tt0050083",
-                          "intro": "The jury in a New York City murder trial is frustrated by a single member whose skeptical caution forces them to more carefully consider the evidence before jumping to a hasty verdict.\n\nSee more info [on IMDB](https://imdb.com/title/tt0050083)",
-                          "image": {
-                              "url": "https://m.media-amazon.com/images/M/MV5BMWU4N2FjNzYtNTVkNC00NzQ0LTg0MjAtYTJlMjFhNGUxZDFmXkEyXkFqcGdeQXVyNjc1NTYyMjg@._V1_.jpg"
-                          },
-                          "createdAt": "2022-01-17T05:01:21.807Z",
-                          "updatedAt": "2022-01-18T08:48:15.429Z",
-                          "publishedAt": "2022-01-17T05:01:24.036Z"
-                      }
-                  }
-              }
-          }
-      },
-      {
-          "id": 16,
-          "attributes": {
-              "start_time": "2022-01-27T21:00:00.000Z",
-              "room": "Stora salongen",
-              "createdAt": "2022-01-23T10:32:07.444Z",
-              "updatedAt": "2022-01-23T10:32:07.444Z",
-              "movie": {
-                  "data": {
-                      "id": 5,
-                      "attributes": {
-                          "title": "12 Angry Men",
-                          "imdbId": "tt0050083",
-                          "intro": "The jury in a New York City murder trial is frustrated by a single member whose skeptical caution forces them to more carefully consider the evidence before jumping to a hasty verdict.\n\nSee more info [on IMDB](https://imdb.com/title/tt0050083)",
-                          "image": {
-                              "url": "https://m.media-amazon.com/images/M/MV5BMWU4N2FjNzYtNTVkNC00NzQ0LTg0MjAtYTJlMjFhNGUxZDFmXkEyXkFqcGdeQXVyNjc1NTYyMjg@._V1_.jpg"
-                          },
-                          "createdAt": "2022-01-17T05:01:21.807Z",
-                          "updatedAt": "2022-01-18T08:48:15.429Z",
-                          "publishedAt": "2022-01-17T05:01:24.036Z"
-                      }
-                  }
-              }
-          }
-      },
-      {
-          "id": 17,
-          "attributes": {
-              "start_time": "2022-01-28T12:00:00.000Z",
-              "room": "Stora salongen",
-              "createdAt": "2022-01-23T10:32:07.991Z",
-              "updatedAt": "2022-01-23T10:32:07.991Z",
-              "movie": {
-                  "data": {
-                      "id": 1,
-                      "attributes": {
-                          "title": "The Shawshank Redemption",
-                          "imdbId": "tt0111161",
-                          "intro": "Two imprisoned men bond over a number of years, finding solace and eventual redemption through acts of common decency.\n\nSee more info [on IMDB](https://imdb.com/title/tt0111161)",
-                          "image": {
-                              "url": "https://m.media-amazon.com/images/M/MV5BMDFkYTc0MGEtZmNhMC00ZDIzLWFmNTEtODM1ZmRlYWMwMWFmXkEyXkFqcGdeQXVyMTMxODk2OTU@._V1_.jpg"
-                          },
-                          "createdAt": "2022-01-17T04:59:14.315Z",
-                          "updatedAt": "2022-01-18T08:47:01.417Z",
-                          "publishedAt": "2022-01-17T04:59:16.846Z"
-                      }
-                  }
-              }
-          }
-      },
-      {
-          "id": 18,
-          "attributes": {
-              "start_time": "2022-01-28T17:00:00.000Z",
-              "room": "Stora salongen",
-              "createdAt": "2022-01-23T10:32:08.517Z",
-              "updatedAt": "2022-01-23T10:32:08.517Z",
-              "movie": {
-                  "data": {
-                      "id": 1,
-                      "attributes": {
-                          "title": "The Shawshank Redemption",
-                          "imdbId": "tt0111161",
-                          "intro": "Two imprisoned men bond over a number of years, finding solace and eventual redemption through acts of common decency.\n\nSee more info [on IMDB](https://imdb.com/title/tt0111161)",
-                          "image": {
-                              "url": "https://m.media-amazon.com/images/M/MV5BMDFkYTc0MGEtZmNhMC00ZDIzLWFmNTEtODM1ZmRlYWMwMWFmXkEyXkFqcGdeQXVyMTMxODk2OTU@._V1_.jpg"
-                          },
-                          "createdAt": "2022-01-17T04:59:14.315Z",
-                          "updatedAt": "2022-01-18T08:47:01.417Z",
-                          "publishedAt": "2022-01-17T04:59:16.846Z"
-                      }
-                  }
-              }
-          }
-      },
-      {
-          "id": 19,
-          "attributes": {
-              "start_time": "2022-01-28T19:00:00.000Z",
-              "room": "Stora salongen",
-              "createdAt": "2022-01-23T10:32:09.055Z",
-              "updatedAt": "2022-01-23T10:32:09.055Z",
-              "movie": {
-                  "data": {
-                      "id": 1,
-                      "attributes": {
-                          "title": "The Shawshank Redemption",
-                          "imdbId": "tt0111161",
-                          "intro": "Two imprisoned men bond over a number of years, finding solace and eventual redemption through acts of common decency.\n\nSee more info [on IMDB](https://imdb.com/title/tt0111161)",
-                          "image": {
-                              "url": "https://m.media-amazon.com/images/M/MV5BMDFkYTc0MGEtZmNhMC00ZDIzLWFmNTEtODM1ZmRlYWMwMWFmXkEyXkFqcGdeQXVyMTMxODk2OTU@._V1_.jpg"
-                          },
-                          "createdAt": "2022-01-17T04:59:14.315Z",
-                          "updatedAt": "2022-01-18T08:47:01.417Z",
-                          "publishedAt": "2022-01-17T04:59:16.846Z"
-                      }
-                  }
-              }
-          }
-      },
-      {
-          "id": 20,
-          "attributes": {
-              "start_time": "2022-01-28T21:00:00.000Z",
-              "room": "Stora salongen",
-              "createdAt": "2022-01-23T10:32:09.591Z",
-              "updatedAt": "2022-01-23T10:32:09.591Z",
-              "movie": {
-                  "data": {
-                      "id": 2,
-                      "attributes": {
-                          "title": "The Godfather",
-                          "imdbId": "tt0068646",
-                          "intro": "The Godfather follows **Vito Corleone**, Don of the Corleone family, as he passes the mantel to his unwilling son, **Michael**.\n\nSee more info [on IMDB](https://imdb.com/title/tt0068646)",
-                          "image": {
-                              "url": "https://m.media-amazon.com/images/M/MV5BM2MyNjYxNmUtYTAwNi00MTYxLWJmNWYtYzZlODY3ZTk3OTFlXkEyXkFqcGdeQXVyNzkwMjQ5NzM@._V1_.jpg"
-                          },
-                          "createdAt": "2022-01-17T04:59:42.763Z",
-                          "updatedAt": "2022-01-18T08:47:25.840Z",
-                          "publishedAt": "2022-01-17T04:59:44.929Z"
-                      }
-                  }
-              }
-          }
-      },
-      {
-          "id": 21,
-          "attributes": {
-              "start_time": "2022-01-29T12:00:00.000Z",
-              "room": "Stora salongen",
-              "createdAt": "2022-01-23T10:32:10.131Z",
-              "updatedAt": "2022-01-23T10:32:10.131Z",
-              "movie": {
-                  "data": {
-                      "id": 10,
-                      "attributes": {
-                          "title": "Threat Level Midnight: The Movie",
-                          "imdbId": "tt11620828",
-                          "intro": "After secret agent **Michael Scarn** (played by Steve Carell) is forced into retirement due to the death of his wife **Catherine Zeta-Scarn**, the President of the United States of America (played by Craig Robinson) requests that he prevents **Goldenface** (played by John Krasinski) from blowing up the NHL All-Star Game and killing several hostages.\n\nSee more info [on IMDB](https://imdb.com/title/tt11620828)",
-                          "image": {
-                              "url": "https://m.media-amazon.com/images/M/MV5BZjMzNzE4ZGItMDI5Zi00ZjE3LThkODctYTlhZWY1ZTdmMGNjXkEyXkFqcGdeQXVyOTExNzM4NDM@._V1_.jpg"
-                          },
-                          "createdAt": "2022-01-17T10:51:45.145Z",
-                          "updatedAt": "2022-01-18T08:47:13.309Z",
-                          "publishedAt": "2022-01-17T10:51:53.355Z"
-                      }
-                  }
-              }
-          }
-      },
-      {
-          "id": 22,
-          "attributes": {
-              "start_time": "2022-01-29T17:00:00.000Z",
-              "room": "Stora salongen",
-              "createdAt": "2022-01-23T10:32:10.695Z",
-              "updatedAt": "2022-01-23T10:32:10.695Z",
-              "movie": {
-                  "data": {
-                      "id": 10,
-                      "attributes": {
-                          "title": "Threat Level Midnight: The Movie",
-                          "imdbId": "tt11620828",
-                          "intro": "After secret agent **Michael Scarn** (played by Steve Carell) is forced into retirement due to the death of his wife **Catherine Zeta-Scarn**, the President of the United States of America (played by Craig Robinson) requests that he prevents **Goldenface** (played by John Krasinski) from blowing up the NHL All-Star Game and killing several hostages.\n\nSee more info [on IMDB](https://imdb.com/title/tt11620828)",
-                          "image": {
-                              "url": "https://m.media-amazon.com/images/M/MV5BZjMzNzE4ZGItMDI5Zi00ZjE3LThkODctYTlhZWY1ZTdmMGNjXkEyXkFqcGdeQXVyOTExNzM4NDM@._V1_.jpg"
-                          },
-                          "createdAt": "2022-01-17T10:51:45.145Z",
-                          "updatedAt": "2022-01-18T08:47:13.309Z",
-                          "publishedAt": "2022-01-17T10:51:53.355Z"
-                      }
-                  }
-              }
-          }
-      },
-      {
-          "id": 23,
-          "attributes": {
-              "start_time": "2022-01-29T19:00:00.000Z",
-              "room": "Stora salongen",
-              "createdAt": "2022-01-23T10:32:11.239Z",
-              "updatedAt": "2022-01-23T10:32:11.239Z",
-              "movie": {
-                  "data": {
-                      "id": 2,
-                      "attributes": {
-                          "title": "The Godfather",
-                          "imdbId": "tt0068646",
-                          "intro": "The Godfather follows **Vito Corleone**, Don of the Corleone family, as he passes the mantel to his unwilling son, **Michael**.\n\nSee more info [on IMDB](https://imdb.com/title/tt0068646)",
-                          "image": {
-                              "url": "https://m.media-amazon.com/images/M/MV5BM2MyNjYxNmUtYTAwNi00MTYxLWJmNWYtYzZlODY3ZTk3OTFlXkEyXkFqcGdeQXVyNzkwMjQ5NzM@._V1_.jpg"
-                          },
-                          "createdAt": "2022-01-17T04:59:42.763Z",
-                          "updatedAt": "2022-01-18T08:47:25.840Z",
-                          "publishedAt": "2022-01-17T04:59:44.929Z"
-                      }
-                  }
-              }
-          }
-      },
-      {
-          "id": 24,
-          "attributes": {
-              "start_time": "2022-01-29T21:00:00.000Z",
-              "room": "Stora salongen",
-              "createdAt": "2022-01-23T10:32:11.766Z",
-              "updatedAt": "2022-01-23T10:32:11.766Z",
-              "movie": {
-                  "data": {
-                      "id": 1,
-                      "attributes": {
-                          "title": "The Shawshank Redemption",
-                          "imdbId": "tt0111161",
-                          "intro": "Two imprisoned men bond over a number of years, finding solace and eventual redemption through acts of common decency.\n\nSee more info [on IMDB](https://imdb.com/title/tt0111161)",
-                          "image": {
-                              "url": "https://m.media-amazon.com/images/M/MV5BMDFkYTc0MGEtZmNhMC00ZDIzLWFmNTEtODM1ZmRlYWMwMWFmXkEyXkFqcGdeQXVyMTMxODk2OTU@._V1_.jpg"
-                          },
-                          "createdAt": "2022-01-17T04:59:14.315Z",
-                          "updatedAt": "2022-01-18T08:47:01.417Z",
-                          "publishedAt": "2022-01-17T04:59:16.846Z"
-                      }
-                  }
-              }
-          }
-      },
-      {
-          "id": 25,
-          "attributes": {
-              "start_time": "2022-01-30T12:00:00.000Z",
-              "room": "Stora salongen",
-              "createdAt": "2022-01-23T10:32:12.316Z",
-              "updatedAt": "2022-01-23T10:32:12.316Z",
-              "movie": {
-                  "data": {
-                      "id": 2,
-                      "attributes": {
-                          "title": "The Godfather",
-                          "imdbId": "tt0068646",
-                          "intro": "The Godfather follows **Vito Corleone**, Don of the Corleone family, as he passes the mantel to his unwilling son, **Michael**.\n\nSee more info [on IMDB](https://imdb.com/title/tt0068646)",
-                          "image": {
-                              "url": "https://m.media-amazon.com/images/M/MV5BM2MyNjYxNmUtYTAwNi00MTYxLWJmNWYtYzZlODY3ZTk3OTFlXkEyXkFqcGdeQXVyNzkwMjQ5NzM@._V1_.jpg"
-                          },
-                          "createdAt": "2022-01-17T04:59:42.763Z",
-                          "updatedAt": "2022-01-18T08:47:25.840Z",
-                          "publishedAt": "2022-01-17T04:59:44.929Z"
-                      }
-                  }
-              }
-          }
-      },
-      {
-          "id": 26,
-          "attributes": {
-              "start_time": "2022-01-30T17:00:00.000Z",
-              "room": "Stora salongen",
-              "createdAt": "2022-01-23T10:32:12.918Z",
-              "updatedAt": "2022-01-23T10:32:12.918Z",
-              "movie": {
-                  "data": {
-                      "id": 2,
-                      "attributes": {
-                          "title": "The Godfather",
-                          "imdbId": "tt0068646",
-                          "intro": "The Godfather follows **Vito Corleone**, Don of the Corleone family, as he passes the mantel to his unwilling son, **Michael**.\n\nSee more info [on IMDB](https://imdb.com/title/tt0068646)",
-                          "image": {
-                              "url": "https://m.media-amazon.com/images/M/MV5BM2MyNjYxNmUtYTAwNi00MTYxLWJmNWYtYzZlODY3ZTk3OTFlXkEyXkFqcGdeQXVyNzkwMjQ5NzM@._V1_.jpg"
-                          },
-                          "createdAt": "2022-01-17T04:59:42.763Z",
-                          "updatedAt": "2022-01-18T08:47:25.840Z",
-                          "publishedAt": "2022-01-17T04:59:44.929Z"
-                      }
-                  }
-              }
-          }
-      },
-      {
-          "id": 27,
-          "attributes": {
-              "start_time": "2022-01-30T19:00:00.000Z",
-              "room": "Stora salongen",
-              "createdAt": "2022-01-23T10:32:13.489Z",
-              "updatedAt": "2022-01-23T10:32:13.489Z",
-              "movie": {
-                  "data": {
-                      "id": 3,
-                      "attributes": {
-                          "title": "The Godfather: Part II",
-                          "imdbId": "tt0071562",
-                          "intro": "The early life and career of **Vito Corleone** in 1920s New York City is portrayed, while his son, **Michael**, expands and tightens his grip on the family crime syndicate.\n\nSee more info [on IMDB](https://imdb.com/title/tt0071562)",
-                          "image": {
-                              "url": "https://m.media-amazon.com/images/M/MV5BMWMwMGQzZTItY2JlNC00OWZiLWIyMDctNDk2ZDQ2YjRjMWQ0XkEyXkFqcGdeQXVyNzkwMjQ5NzM@._V1_.jpg"
-                          },
-                          "createdAt": "2022-01-17T05:00:31.562Z",
-                          "updatedAt": "2022-01-18T08:46:47.388Z",
-                          "publishedAt": "2022-01-17T05:00:33.453Z"
-                      }
-                  }
-              }
-          }
-      },
-      {
-          "id": 28,
-          "attributes": {
-              "start_time": "2022-01-30T21:00:00.000Z",
-              "room": "Stora salongen",
-              "createdAt": "2022-01-23T10:32:14.039Z",
-              "updatedAt": "2022-01-23T10:32:14.039Z",
-              "movie": {
-                  "data": {
-                      "id": 2,
-                      "attributes": {
-                          "title": "The Godfather",
-                          "imdbId": "tt0068646",
-                          "intro": "The Godfather follows **Vito Corleone**, Don of the Corleone family, as he passes the mantel to his unwilling son, **Michael**.\n\nSee more info [on IMDB](https://imdb.com/title/tt0068646)",
-                          "image": {
-                              "url": "https://m.media-amazon.com/images/M/MV5BM2MyNjYxNmUtYTAwNi00MTYxLWJmNWYtYzZlODY3ZTk3OTFlXkEyXkFqcGdeQXVyNzkwMjQ5NzM@._V1_.jpg"
-                          },
-                          "createdAt": "2022-01-17T04:59:42.763Z",
-                          "updatedAt": "2022-01-18T08:47:25.840Z",
-                          "publishedAt": "2022-01-17T04:59:44.929Z"
-                      }
-                  }
-              }
-          }
-      },
-      {
-          "id": 29,
-          "attributes": {
-              "start_time": "2022-01-31T12:00:00.000Z",
-              "room": "Stora salongen",
-              "createdAt": "2022-01-23T10:32:14.668Z",
-              "updatedAt": "2022-01-23T10:32:14.668Z",
-              "movie": {
-                  "data": {
-                      "id": 10,
-                      "attributes": {
-                          "title": "Threat Level Midnight: The Movie",
-                          "imdbId": "tt11620828",
-                          "intro": "After secret agent **Michael Scarn** (played by Steve Carell) is forced into retirement due to the death of his wife **Catherine Zeta-Scarn**, the President of the United States of America (played by Craig Robinson) requests that he prevents **Goldenface** (played by John Krasinski) from blowing up the NHL All-Star Game and killing several hostages.\n\nSee more info [on IMDB](https://imdb.com/title/tt11620828)",
-                          "image": {
-                              "url": "https://m.media-amazon.com/images/M/MV5BZjMzNzE4ZGItMDI5Zi00ZjE3LThkODctYTlhZWY1ZTdmMGNjXkEyXkFqcGdeQXVyOTExNzM4NDM@._V1_.jpg"
-                          },
-                          "createdAt": "2022-01-17T10:51:45.145Z",
-                          "updatedAt": "2022-01-18T08:47:13.309Z",
-                          "publishedAt": "2022-01-17T10:51:53.355Z"
-                      }
-                  }
-              }
-          }
-      },
-      {
-          "id": 30,
-          "attributes": {
-              "start_time": "2022-01-31T17:00:00.000Z",
-              "room": "Stora salongen",
-              "createdAt": "2022-01-23T10:32:15.220Z",
-              "updatedAt": "2022-01-23T10:32:15.220Z",
-              "movie": {
-                  "data": {
-                      "id": 2,
-                      "attributes": {
-                          "title": "The Godfather",
-                          "imdbId": "tt0068646",
-                          "intro": "The Godfather follows **Vito Corleone**, Don of the Corleone family, as he passes the mantel to his unwilling son, **Michael**.\n\nSee more info [on IMDB](https://imdb.com/title/tt0068646)",
-                          "image": {
-                              "url": "https://m.media-amazon.com/images/M/MV5BM2MyNjYxNmUtYTAwNi00MTYxLWJmNWYtYzZlODY3ZTk3OTFlXkEyXkFqcGdeQXVyNzkwMjQ5NzM@._V1_.jpg"
-                          },
-                          "createdAt": "2022-01-17T04:59:42.763Z",
-                          "updatedAt": "2022-01-18T08:47:25.840Z",
-                          "publishedAt": "2022-01-17T04:59:44.929Z"
-                      }
-                  }
-              }
-          }
-      },
-      {
-          "id": 31,
-          "attributes": {
-              "start_time": "2022-01-31T19:00:00.000Z",
-              "room": "Stora salongen",
-              "createdAt": "2022-01-23T10:32:15.771Z",
-              "updatedAt": "2022-01-23T10:32:15.771Z",
-              "movie": {
-                  "data": {
-                      "id": 4,
-                      "attributes": {
-                          "title": "The Dark Knight",
-                          "imdbId": "tt0468569",
-                          "intro": "When the menace known as the Joker wreaks havoc and chaos on the people of Gotham, **Batman** must accept one of the greatest psychological and physical tests of his ability to fight injustice.\n\nSee more info [on IMDB](https://imdb.com/title/tt0468569)",
-                          "image": {
-                              "url": "https://m.media-amazon.com/images/M/MV5BMTMxNTMwODM0NF5BMl5BanBnXkFtZTcwODAyMTk2Mw@@._V1_.jpg"
-                          },
-                          "createdAt": "2022-01-17T05:00:58.423Z",
-                          "updatedAt": "2022-01-18T08:47:52.866Z",
-                          "publishedAt": "2022-01-17T05:01:00.594Z"
-                      }
-                  }
-              }
-          }
-      },
-      {
-          "id": 32,
-          "attributes": {
-              "start_time": "2022-01-31T21:00:00.000Z",
-              "room": "Stora salongen",
-              "createdAt": "2022-01-23T10:32:16.822Z",
-              "updatedAt": "2022-01-23T10:32:16.822Z",
-              "movie": {
-                  "data": {
-                      "id": 2,
-                      "attributes": {
-                          "title": "The Godfather",
-                          "imdbId": "tt0068646",
-                          "intro": "The Godfather follows **Vito Corleone**, Don of the Corleone family, as he passes the mantel to his unwilling son, **Michael**.\n\nSee more info [on IMDB](https://imdb.com/title/tt0068646)",
-                          "image": {
-                              "url": "https://m.media-amazon.com/images/M/MV5BM2MyNjYxNmUtYTAwNi00MTYxLWJmNWYtYzZlODY3ZTk3OTFlXkEyXkFqcGdeQXVyNzkwMjQ5NzM@._V1_.jpg"
-                          },
-                          "createdAt": "2022-01-17T04:59:42.763Z",
-                          "updatedAt": "2022-01-18T08:47:25.840Z",
-                          "publishedAt": "2022-01-17T04:59:44.929Z"
-                      }
-                  }
-              }
-          }
-      },
-      {
-          "id": 33,
-          "attributes": {
-              "start_time": "2022-02-01T12:00:00.000Z",
-              "room": "Stora salongen",
-              "createdAt": "2022-01-23T10:32:17.391Z",
-              "updatedAt": "2022-01-23T10:32:17.391Z",
-              "movie": {
-                  "data": {
-                      "id": 8,
-                      "attributes": {
-                          "title": "Idiocracy",
-                          "imdbId": "tt0387808",
-                          "intro": "Private **Joe Bauers**, a decisively average American, is selected as a guinea pig for a top-secret hibernation program but is forgotten, awakening to a future so incredibly moronic he's easily the most intelligent person alive.\n\nSee more info [on IMDB](https://imdb.com/title/tt0387808)",
-                          "image": {
-                              "url": "https://m.media-amazon.com/images/M/MV5BMWQ4MzI2ZDQtYjk3MS00ODdjLTkwN2QtOTBjYzIwM2RmNzgyXkEyXkFqcGdeQXVyMTQxNzMzNDI@._V1_.jpg"
-                          },
-                          "createdAt": "2022-01-17T09:32:08.570Z",
-                          "updatedAt": "2022-01-18T08:48:02.876Z",
-                          "publishedAt": "2022-01-17T09:32:12.868Z"
-                      }
-                  }
-              }
-          }
-      },
-      {
-          "id": 34,
-          "attributes": {
-              "start_time": "2022-02-01T17:00:00.000Z",
-              "room": "Stora salongen",
-              "createdAt": "2022-01-23T10:32:17.954Z",
-              "updatedAt": "2022-01-23T10:32:17.954Z",
-              "movie": {
-                  "data": {
-                      "id": 1,
-                      "attributes": {
-                          "title": "The Shawshank Redemption",
-                          "imdbId": "tt0111161",
-                          "intro": "Two imprisoned men bond over a number of years, finding solace and eventual redemption through acts of common decency.\n\nSee more info [on IMDB](https://imdb.com/title/tt0111161)",
-                          "image": {
-                              "url": "https://m.media-amazon.com/images/M/MV5BMDFkYTc0MGEtZmNhMC00ZDIzLWFmNTEtODM1ZmRlYWMwMWFmXkEyXkFqcGdeQXVyMTMxODk2OTU@._V1_.jpg"
-                          },
-                          "createdAt": "2022-01-17T04:59:14.315Z",
-                          "updatedAt": "2022-01-18T08:47:01.417Z",
-                          "publishedAt": "2022-01-17T04:59:16.846Z"
-                      }
-                  }
-              }
-          }
-      },
-      {
-          "id": 35,
-          "attributes": {
-              "start_time": "2022-02-01T19:00:00.000Z",
-              "room": "Stora salongen",
-              "createdAt": "2022-01-23T10:32:18.516Z",
-              "updatedAt": "2022-01-23T10:32:18.516Z",
-              "movie": {
-                  "data": {
-                      "id": 3,
-                      "attributes": {
-                          "title": "The Godfather: Part II",
-                          "imdbId": "tt0071562",
-                          "intro": "The early life and career of **Vito Corleone** in 1920s New York City is portrayed, while his son, **Michael**, expands and tightens his grip on the family crime syndicate.\n\nSee more info [on IMDB](https://imdb.com/title/tt0071562)",
-                          "image": {
-                              "url": "https://m.media-amazon.com/images/M/MV5BMWMwMGQzZTItY2JlNC00OWZiLWIyMDctNDk2ZDQ2YjRjMWQ0XkEyXkFqcGdeQXVyNzkwMjQ5NzM@._V1_.jpg"
-                          },
-                          "createdAt": "2022-01-17T05:00:31.562Z",
-                          "updatedAt": "2022-01-18T08:46:47.388Z",
-                          "publishedAt": "2022-01-17T05:00:33.453Z"
-                      }
-                  }
-              }
-          }
-      },
-      {
-          "id": 36,
-          "attributes": {
-              "start_time": "2022-02-01T21:00:00.000Z",
-              "room": "Stora salongen",
-              "createdAt": "2022-01-23T10:32:19.051Z",
-              "updatedAt": "2022-01-23T10:32:19.051Z",
-              "movie": {
-                  "data": {
-                      "id": 2,
-                      "attributes": {
-                          "title": "The Godfather",
-                          "imdbId": "tt0068646",
-                          "intro": "The Godfather follows **Vito Corleone**, Don of the Corleone family, as he passes the mantel to his unwilling son, **Michael**.\n\nSee more info [on IMDB](https://imdb.com/title/tt0068646)",
-                          "image": {
-                              "url": "https://m.media-amazon.com/images/M/MV5BM2MyNjYxNmUtYTAwNi00MTYxLWJmNWYtYzZlODY3ZTk3OTFlXkEyXkFqcGdeQXVyNzkwMjQ5NzM@._V1_.jpg"
-                          },
-                          "createdAt": "2022-01-17T04:59:42.763Z",
-                          "updatedAt": "2022-01-18T08:47:25.840Z",
-                          "publishedAt": "2022-01-17T04:59:44.929Z"
-                      }
-                  }
-              }
-          }
-      },
-      {
-          "id": 37,
-          "attributes": {
-              "start_time": "2022-02-02T12:00:00.000Z",
-              "room": "Stora salongen",
-              "createdAt": "2022-01-23T10:32:19.612Z",
-              "updatedAt": "2022-01-23T10:32:19.612Z",
-              "movie": {
-                  "data": {
-                      "id": 8,
-                      "attributes": {
-                          "title": "Idiocracy",
-                          "imdbId": "tt0387808",
-                          "intro": "Private **Joe Bauers**, a decisively average American, is selected as a guinea pig for a top-secret hibernation program but is forgotten, awakening to a future so incredibly moronic he's easily the most intelligent person alive.\n\nSee more info [on IMDB](https://imdb.com/title/tt0387808)",
-                          "image": {
-                              "url": "https://m.media-amazon.com/images/M/MV5BMWQ4MzI2ZDQtYjk3MS00ODdjLTkwN2QtOTBjYzIwM2RmNzgyXkEyXkFqcGdeQXVyMTQxNzMzNDI@._V1_.jpg"
-                          },
-                          "createdAt": "2022-01-17T09:32:08.570Z",
-                          "updatedAt": "2022-01-18T08:48:02.876Z",
-                          "publishedAt": "2022-01-17T09:32:12.868Z"
-                      }
-                  }
-              }
-          }
-      },
-      {
-          "id": 38,
-          "attributes": {
-              "start_time": "2022-02-02T17:00:00.000Z",
-              "room": "Stora salongen",
-              "createdAt": "2022-01-23T10:32:20.188Z",
-              "updatedAt": "2022-01-23T10:32:20.188Z",
-              "movie": {
-                  "data": {
-                      "id": 2,
-                      "attributes": {
-                          "title": "The Godfather",
-                          "imdbId": "tt0068646",
-                          "intro": "The Godfather follows **Vito Corleone**, Don of the Corleone family, as he passes the mantel to his unwilling son, **Michael**.\n\nSee more info [on IMDB](https://imdb.com/title/tt0068646)",
-                          "image": {
-                              "url": "https://m.media-amazon.com/images/M/MV5BM2MyNjYxNmUtYTAwNi00MTYxLWJmNWYtYzZlODY3ZTk3OTFlXkEyXkFqcGdeQXVyNzkwMjQ5NzM@._V1_.jpg"
-                          },
-                          "createdAt": "2022-01-17T04:59:42.763Z",
-                          "updatedAt": "2022-01-18T08:47:25.840Z",
-                          "publishedAt": "2022-01-17T04:59:44.929Z"
-                      }
-                  }
-              }
-          }
-      },
-      {
-          "id": 39,
-          "attributes": {
-              "start_time": "2022-02-02T19:00:00.000Z",
-              "room": "Stora salongen",
-              "createdAt": "2022-01-23T10:32:20.722Z",
-              "updatedAt": "2022-01-23T10:32:20.722Z",
-              "movie": {
-                  "data": {
-                      "id": 4,
-                      "attributes": {
-                          "title": "The Dark Knight",
-                          "imdbId": "tt0468569",
-                          "intro": "When the menace known as the Joker wreaks havoc and chaos on the people of Gotham, **Batman** must accept one of the greatest psychological and physical tests of his ability to fight injustice.\n\nSee more info [on IMDB](https://imdb.com/title/tt0468569)",
-                          "image": {
-                              "url": "https://m.media-amazon.com/images/M/MV5BMTMxNTMwODM0NF5BMl5BanBnXkFtZTcwODAyMTk2Mw@@._V1_.jpg"
-                          },
-                          "createdAt": "2022-01-17T05:00:58.423Z",
-                          "updatedAt": "2022-01-18T08:47:52.866Z",
-                          "publishedAt": "2022-01-17T05:01:00.594Z"
-                      }
-                  }
-              }
-          }
-      },
-      {
-          "id": 40,
-          "attributes": {
-              "start_time": "2022-02-02T21:00:00.000Z",
-              "room": "Stora salongen",
-              "createdAt": "2022-01-23T10:32:21.266Z",
-              "updatedAt": "2022-01-23T10:32:21.266Z",
-              "movie": {
-                  "data": {
-                      "id": 1,
-                      "attributes": {
-                          "title": "The Shawshank Redemption",
-                          "imdbId": "tt0111161",
-                          "intro": "Two imprisoned men bond over a number of years, finding solace and eventual redemption through acts of common decency.\n\nSee more info [on IMDB](https://imdb.com/title/tt0111161)",
-                          "image": {
-                              "url": "https://m.media-amazon.com/images/M/MV5BMDFkYTc0MGEtZmNhMC00ZDIzLWFmNTEtODM1ZmRlYWMwMWFmXkEyXkFqcGdeQXVyMTMxODk2OTU@._V1_.jpg"
-                          },
-                          "createdAt": "2022-01-17T04:59:14.315Z",
-                          "updatedAt": "2022-01-18T08:47:01.417Z",
-                          "publishedAt": "2022-01-17T04:59:16.846Z"
-                      }
-                  }
-              }
-          }
-      },
-      {
-          "id": 41,
-          "attributes": {
-              "start_time": "2022-02-03T12:00:00.000Z",
-              "room": "Stora salongen",
-              "createdAt": "2022-01-23T10:32:21.864Z",
-              "updatedAt": "2022-01-23T10:32:21.864Z",
-              "movie": {
-                  "data": {
-                      "id": 1,
-                      "attributes": {
-                          "title": "The Shawshank Redemption",
-                          "imdbId": "tt0111161",
-                          "intro": "Two imprisoned men bond over a number of years, finding solace and eventual redemption through acts of common decency.\n\nSee more info [on IMDB](https://imdb.com/title/tt0111161)",
-                          "image": {
-                              "url": "https://m.media-amazon.com/images/M/MV5BMDFkYTc0MGEtZmNhMC00ZDIzLWFmNTEtODM1ZmRlYWMwMWFmXkEyXkFqcGdeQXVyMTMxODk2OTU@._V1_.jpg"
-                          },
-                          "createdAt": "2022-01-17T04:59:14.315Z",
-                          "updatedAt": "2022-01-18T08:47:01.417Z",
-                          "publishedAt": "2022-01-17T04:59:16.846Z"
-                      }
-                  }
-              }
-          }
-      },
-      {
-          "id": 42,
-          "attributes": {
-              "start_time": "2022-02-03T17:00:00.000Z",
-              "room": "Stora salongen",
-              "createdAt": "2022-01-23T10:32:22.392Z",
-              "updatedAt": "2022-01-23T10:32:22.392Z",
-              "movie": {
-                  "data": {
-                      "id": 5,
-                      "attributes": {
-                          "title": "12 Angry Men",
-                          "imdbId": "tt0050083",
-                          "intro": "The jury in a New York City murder trial is frustrated by a single member whose skeptical caution forces them to more carefully consider the evidence before jumping to a hasty verdict.\n\nSee more info [on IMDB](https://imdb.com/title/tt0050083)",
-                          "image": {
-                              "url": "https://m.media-amazon.com/images/M/MV5BMWU4N2FjNzYtNTVkNC00NzQ0LTg0MjAtYTJlMjFhNGUxZDFmXkEyXkFqcGdeQXVyNjc1NTYyMjg@._V1_.jpg"
-                          },
-                          "createdAt": "2022-01-17T05:01:21.807Z",
-                          "updatedAt": "2022-01-18T08:48:15.429Z",
-                          "publishedAt": "2022-01-17T05:01:24.036Z"
-                      }
-                  }
-              }
-          }
-      },
-      {
-          "id": 43,
-          "attributes": {
-              "start_time": "2022-02-03T19:00:00.000Z",
-              "room": "Stora salongen",
-              "createdAt": "2022-01-23T10:32:22.955Z",
-              "updatedAt": "2022-01-23T10:32:22.955Z",
-              "movie": {
-                  "data": {
-                      "id": 2,
-                      "attributes": {
-                          "title": "The Godfather",
-                          "imdbId": "tt0068646",
-                          "intro": "The Godfather follows **Vito Corleone**, Don of the Corleone family, as he passes the mantel to his unwilling son, **Michael**.\n\nSee more info [on IMDB](https://imdb.com/title/tt0068646)",
-                          "image": {
-                              "url": "https://m.media-amazon.com/images/M/MV5BM2MyNjYxNmUtYTAwNi00MTYxLWJmNWYtYzZlODY3ZTk3OTFlXkEyXkFqcGdeQXVyNzkwMjQ5NzM@._V1_.jpg"
-                          },
-                          "createdAt": "2022-01-17T04:59:42.763Z",
-                          "updatedAt": "2022-01-18T08:47:25.840Z",
-                          "publishedAt": "2022-01-17T04:59:44.929Z"
-                      }
-                  }
-              }
-          }
-      },
-      {
-          "id": 44,
-          "attributes": {
-              "start_time": "2022-02-03T21:00:00.000Z",
-              "room": "Stora salongen",
-              "createdAt": "2022-01-23T10:32:23.740Z",
-              "updatedAt": "2022-01-23T10:32:23.740Z",
-              "movie": {
-                  "data": {
-                      "id": 3,
-                      "attributes": {
-                          "title": "The Godfather: Part II",
-                          "imdbId": "tt0071562",
-                          "intro": "The early life and career of **Vito Corleone** in 1920s New York City is portrayed, while his son, **Michael**, expands and tightens his grip on the family crime syndicate.\n\nSee more info [on IMDB](https://imdb.com/title/tt0071562)",
-                          "image": {
-                              "url": "https://m.media-amazon.com/images/M/MV5BMWMwMGQzZTItY2JlNC00OWZiLWIyMDctNDk2ZDQ2YjRjMWQ0XkEyXkFqcGdeQXVyNzkwMjQ5NzM@._V1_.jpg"
-                          },
-                          "createdAt": "2022-01-17T05:00:31.562Z",
-                          "updatedAt": "2022-01-18T08:46:47.388Z",
-                          "publishedAt": "2022-01-17T05:00:33.453Z"
-                      }
-                  }
-              }
-          }
-      },
-      {
-          "id": 45,
-          "attributes": {
-              "start_time": "2022-02-04T12:00:00.000Z",
-              "room": "Stora salongen",
-              "createdAt": "2022-01-23T10:32:24.272Z",
-              "updatedAt": "2022-01-23T10:32:24.272Z",
-              "movie": {
-                  "data": {
-                      "id": 5,
-                      "attributes": {
-                          "title": "12 Angry Men",
-                          "imdbId": "tt0050083",
-                          "intro": "The jury in a New York City murder trial is frustrated by a single member whose skeptical caution forces them to more carefully consider the evidence before jumping to a hasty verdict.\n\nSee more info [on IMDB](https://imdb.com/title/tt0050083)",
-                          "image": {
-                              "url": "https://m.media-amazon.com/images/M/MV5BMWU4N2FjNzYtNTVkNC00NzQ0LTg0MjAtYTJlMjFhNGUxZDFmXkEyXkFqcGdeQXVyNjc1NTYyMjg@._V1_.jpg"
-                          },
-                          "createdAt": "2022-01-17T05:01:21.807Z",
-                          "updatedAt": "2022-01-18T08:48:15.429Z",
-                          "publishedAt": "2022-01-17T05:01:24.036Z"
-                      }
-                  }
-              }
-          }
-      },
-      {
-          "id": 46,
-          "attributes": {
-              "start_time": "2022-02-04T17:00:00.000Z",
-              "room": "Stora salongen",
-              "createdAt": "2022-01-23T10:32:24.811Z",
-              "updatedAt": "2022-01-23T10:32:24.811Z",
-              "movie": {
-                  "data": {
-                      "id": 3,
-                      "attributes": {
-                          "title": "The Godfather: Part II",
-                          "imdbId": "tt0071562",
-                          "intro": "The early life and career of **Vito Corleone** in 1920s New York City is portrayed, while his son, **Michael**, expands and tightens his grip on the family crime syndicate.\n\nSee more info [on IMDB](https://imdb.com/title/tt0071562)",
-                          "image": {
-                              "url": "https://m.media-amazon.com/images/M/MV5BMWMwMGQzZTItY2JlNC00OWZiLWIyMDctNDk2ZDQ2YjRjMWQ0XkEyXkFqcGdeQXVyNzkwMjQ5NzM@._V1_.jpg"
-                          },
-                          "createdAt": "2022-01-17T05:00:31.562Z",
-                          "updatedAt": "2022-01-18T08:46:47.388Z",
-                          "publishedAt": "2022-01-17T05:00:33.453Z"
-                      }
-                  }
-              }
-          }
-      },
-      {
-          "id": 47,
-          "attributes": {
-              "start_time": "2022-02-04T19:00:00.000Z",
-              "room": "Stora salongen",
-              "createdAt": "2022-01-23T10:32:25.382Z",
-              "updatedAt": "2022-01-23T10:32:25.382Z",
-              "movie": {
-                  "data": {
-                      "id": 1,
-                      "attributes": {
-                          "title": "The Shawshank Redemption",
-                          "imdbId": "tt0111161",
-                          "intro": "Two imprisoned men bond over a number of years, finding solace and eventual redemption through acts of common decency.\n\nSee more info [on IMDB](https://imdb.com/title/tt0111161)",
-                          "image": {
-                              "url": "https://m.media-amazon.com/images/M/MV5BMDFkYTc0MGEtZmNhMC00ZDIzLWFmNTEtODM1ZmRlYWMwMWFmXkEyXkFqcGdeQXVyMTMxODk2OTU@._V1_.jpg"
-                          },
-                          "createdAt": "2022-01-17T04:59:14.315Z",
-                          "updatedAt": "2022-01-18T08:47:01.417Z",
-                          "publishedAt": "2022-01-17T04:59:16.846Z"
-                      }
-                  }
-              }
-          }
-      },
-      {
-          "id": 48,
-          "attributes": {
-              "start_time": "2022-02-04T21:00:00.000Z",
-              "room": "Stora salongen",
-              "createdAt": "2022-01-23T10:32:25.918Z",
-              "updatedAt": "2022-01-23T10:32:25.918Z",
-              "movie": {
-                  "data": {
-                      "id": 4,
-                      "attributes": {
-                          "title": "The Dark Knight",
-                          "imdbId": "tt0468569",
-                          "intro": "When the menace known as the Joker wreaks havoc and chaos on the people of Gotham, **Batman** must accept one of the greatest psychological and physical tests of his ability to fight injustice.\n\nSee more info [on IMDB](https://imdb.com/title/tt0468569)",
-                          "image": {
-                              "url": "https://m.media-amazon.com/images/M/MV5BMTMxNTMwODM0NF5BMl5BanBnXkFtZTcwODAyMTk2Mw@@._V1_.jpg"
-                          },
-                          "createdAt": "2022-01-17T05:00:58.423Z",
-                          "updatedAt": "2022-01-18T08:47:52.866Z",
-                          "publishedAt": "2022-01-17T05:01:00.594Z"
-                      }
-                  }
-              }
-          }
-      },
-      {
-          "id": 49,
-          "attributes": {
-              "start_time": "2022-02-05T12:00:00.000Z",
-              "room": "Stora salongen",
-              "createdAt": "2022-01-23T10:32:26.441Z",
-              "updatedAt": "2022-01-23T10:32:26.441Z",
-              "movie": {
-                  "data": {
-                      "id": 5,
-                      "attributes": {
-                          "title": "12 Angry Men",
-                          "imdbId": "tt0050083",
-                          "intro": "The jury in a New York City murder trial is frustrated by a single member whose skeptical caution forces them to more carefully consider the evidence before jumping to a hasty verdict.\n\nSee more info [on IMDB](https://imdb.com/title/tt0050083)",
-                          "image": {
-                              "url": "https://m.media-amazon.com/images/M/MV5BMWU4N2FjNzYtNTVkNC00NzQ0LTg0MjAtYTJlMjFhNGUxZDFmXkEyXkFqcGdeQXVyNjc1NTYyMjg@._V1_.jpg"
-                          },
-                          "createdAt": "2022-01-17T05:01:21.807Z",
-                          "updatedAt": "2022-01-18T08:48:15.429Z",
-                          "publishedAt": "2022-01-17T05:01:24.036Z"
-                      }
-                  }
-              }
-          }
-      },
-      {
-          "id": 50,
-          "attributes": {
-              "start_time": "2022-02-05T17:00:00.000Z",
-              "room": "Stora salongen",
-              "createdAt": "2022-01-23T10:32:26.971Z",
-              "updatedAt": "2022-01-23T10:32:26.971Z",
-              "movie": {
-                  "data": {
-                      "id": 8,
-                      "attributes": {
-                          "title": "Idiocracy",
-                          "imdbId": "tt0387808",
-                          "intro": "Private **Joe Bauers**, a decisively average American, is selected as a guinea pig for a top-secret hibernation program but is forgotten, awakening to a future so incredibly moronic he's easily the most intelligent person alive.\n\nSee more info [on IMDB](https://imdb.com/title/tt0387808)",
-                          "image": {
-                              "url": "https://m.media-amazon.com/images/M/MV5BMWQ4MzI2ZDQtYjk3MS00ODdjLTkwN2QtOTBjYzIwM2RmNzgyXkEyXkFqcGdeQXVyMTQxNzMzNDI@._V1_.jpg"
-                          },
-                          "createdAt": "2022-01-17T09:32:08.570Z",
-                          "updatedAt": "2022-01-18T08:48:02.876Z",
-                          "publishedAt": "2022-01-17T09:32:12.868Z"
-                      }
-                  }
-              }
-          }
-      },
-      {
-          "id": 51,
-          "attributes": {
-              "start_time": "2022-02-05T19:00:00.000Z",
-              "room": "Stora salongen",
-              "createdAt": "2022-01-23T10:32:27.507Z",
-              "updatedAt": "2022-01-23T10:32:27.507Z",
-              "movie": {
-                  "data": {
-                      "id": 10,
-                      "attributes": {
-                          "title": "Threat Level Midnight: The Movie",
-                          "imdbId": "tt11620828",
-                          "intro": "After secret agent **Michael Scarn** (played by Steve Carell) is forced into retirement due to the death of his wife **Catherine Zeta-Scarn**, the President of the United States of America (played by Craig Robinson) requests that he prevents **Goldenface** (played by John Krasinski) from blowing up the NHL All-Star Game and killing several hostages.\n\nSee more info [on IMDB](https://imdb.com/title/tt11620828)",
-                          "image": {
-                              "url": "https://m.media-amazon.com/images/M/MV5BZjMzNzE4ZGItMDI5Zi00ZjE3LThkODctYTlhZWY1ZTdmMGNjXkEyXkFqcGdeQXVyOTExNzM4NDM@._V1_.jpg"
-                          },
-                          "createdAt": "2022-01-17T10:51:45.145Z",
-                          "updatedAt": "2022-01-18T08:47:13.309Z",
-                          "publishedAt": "2022-01-17T10:51:53.355Z"
-                      }
-                  }
-              }
-          }
-      },
-      {
-          "id": 52,
-          "attributes": {
-              "start_time": "2022-02-05T21:00:00.000Z",
-              "room": "Stora salongen",
-              "createdAt": "2022-01-23T10:32:28.083Z",
-              "updatedAt": "2022-01-23T10:32:28.083Z",
-              "movie": {
-                  "data": {
-                      "id": 4,
-                      "attributes": {
-                          "title": "The Dark Knight",
-                          "imdbId": "tt0468569",
-                          "intro": "When the menace known as the Joker wreaks havoc and chaos on the people of Gotham, **Batman** must accept one of the greatest psychological and physical tests of his ability to fight injustice.\n\nSee more info [on IMDB](https://imdb.com/title/tt0468569)",
-                          "image": {
-                              "url": "https://m.media-amazon.com/images/M/MV5BMTMxNTMwODM0NF5BMl5BanBnXkFtZTcwODAyMTk2Mw@@._V1_.jpg"
-                          },
-                          "createdAt": "2022-01-17T05:00:58.423Z",
-                          "updatedAt": "2022-01-18T08:47:52.866Z",
-                          "publishedAt": "2022-01-17T05:01:00.594Z"
-                      }
-                  }
-              }
-          }
-      },
-      {
-          "id": 53,
-          "attributes": {
-              "start_time": "2022-02-06T12:00:00.000Z",
-              "room": "Stora salongen",
-              "createdAt": "2022-01-23T10:32:28.663Z",
-              "updatedAt": "2022-01-23T10:32:28.663Z",
-              "movie": {
-                  "data": {
-                      "id": 5,
-                      "attributes": {
-                          "title": "12 Angry Men",
-                          "imdbId": "tt0050083",
-                          "intro": "The jury in a New York City murder trial is frustrated by a single member whose skeptical caution forces them to more carefully consider the evidence before jumping to a hasty verdict.\n\nSee more info [on IMDB](https://imdb.com/title/tt0050083)",
-                          "image": {
-                              "url": "https://m.media-amazon.com/images/M/MV5BMWU4N2FjNzYtNTVkNC00NzQ0LTg0MjAtYTJlMjFhNGUxZDFmXkEyXkFqcGdeQXVyNjc1NTYyMjg@._V1_.jpg"
-                          },
-                          "createdAt": "2022-01-17T05:01:21.807Z",
-                          "updatedAt": "2022-01-18T08:48:15.429Z",
-                          "publishedAt": "2022-01-17T05:01:24.036Z"
-                      }
-                  }
-              }
-          }
-      },
-      {
-          "id": 54,
-          "attributes": {
-              "start_time": "2022-02-06T17:00:00.000Z",
-              "room": "Stora salongen",
-              "createdAt": "2022-01-23T10:32:29.220Z",
-              "updatedAt": "2022-01-23T10:32:29.220Z",
-              "movie": {
-                  "data": {
-                      "id": 4,
-                      "attributes": {
-                          "title": "The Dark Knight",
-                          "imdbId": "tt0468569",
-                          "intro": "When the menace known as the Joker wreaks havoc and chaos on the people of Gotham, **Batman** must accept one of the greatest psychological and physical tests of his ability to fight injustice.\n\nSee more info [on IMDB](https://imdb.com/title/tt0468569)",
-                          "image": {
-                              "url": "https://m.media-amazon.com/images/M/MV5BMTMxNTMwODM0NF5BMl5BanBnXkFtZTcwODAyMTk2Mw@@._V1_.jpg"
-                          },
-                          "createdAt": "2022-01-17T05:00:58.423Z",
-                          "updatedAt": "2022-01-18T08:47:52.866Z",
-                          "publishedAt": "2022-01-17T05:01:00.594Z"
-                      }
-                  }
-              }
-          }
-      },
-      {
-          "id": 55,
-          "attributes": {
-              "start_time": "2022-02-06T19:00:00.000Z",
-              "room": "Stora salongen",
-              "createdAt": "2022-01-23T10:32:30.046Z",
-              "updatedAt": "2022-01-23T10:32:30.046Z",
-              "movie": {
-                  "data": {
-                      "id": 5,
-                      "attributes": {
-                          "title": "12 Angry Men",
-                          "imdbId": "tt0050083",
-                          "intro": "The jury in a New York City murder trial is frustrated by a single member whose skeptical caution forces them to more carefully consider the evidence before jumping to a hasty verdict.\n\nSee more info [on IMDB](https://imdb.com/title/tt0050083)",
-                          "image": {
-                              "url": "https://m.media-amazon.com/images/M/MV5BMWU4N2FjNzYtNTVkNC00NzQ0LTg0MjAtYTJlMjFhNGUxZDFmXkEyXkFqcGdeQXVyNjc1NTYyMjg@._V1_.jpg"
-                          },
-                          "createdAt": "2022-01-17T05:01:21.807Z",
-                          "updatedAt": "2022-01-18T08:48:15.429Z",
-                          "publishedAt": "2022-01-17T05:01:24.036Z"
-                      }
-                  }
-              }
-          }
-      },
-      {
-          "id": 56,
-          "attributes": {
-              "start_time": "2022-02-06T21:00:00.000Z",
-              "room": "Stora salongen",
-              "createdAt": "2022-01-23T10:32:30.580Z",
-              "updatedAt": "2022-01-23T10:32:30.580Z",
-              "movie": {
-                  "data": {
-                      "id": 3,
-                      "attributes": {
-                          "title": "The Godfather: Part II",
-                          "imdbId": "tt0071562",
-                          "intro": "The early life and career of **Vito Corleone** in 1920s New York City is portrayed, while his son, **Michael**, expands and tightens his grip on the family crime syndicate.\n\nSee more info [on IMDB](https://imdb.com/title/tt0071562)",
-                          "image": {
-                              "url": "https://m.media-amazon.com/images/M/MV5BMWMwMGQzZTItY2JlNC00OWZiLWIyMDctNDk2ZDQ2YjRjMWQ0XkEyXkFqcGdeQXVyNzkwMjQ5NzM@._V1_.jpg"
-                          },
-                          "createdAt": "2022-01-17T05:00:31.562Z",
-                          "updatedAt": "2022-01-18T08:46:47.388Z",
-                          "publishedAt": "2022-01-17T05:00:33.453Z"
-                      }
-                  }
-              }
-          }
-      },
-      {
-          "id": 57,
-          "attributes": {
-              "start_time": "2022-02-07T12:00:00.000Z",
-              "room": "Stora salongen",
-              "createdAt": "2022-01-23T10:32:31.119Z",
-              "updatedAt": "2022-01-23T10:32:31.119Z",
-              "movie": {
-                  "data": {
-                      "id": 4,
-                      "attributes": {
-                          "title": "The Dark Knight",
-                          "imdbId": "tt0468569",
-                          "intro": "When the menace known as the Joker wreaks havoc and chaos on the people of Gotham, **Batman** must accept one of the greatest psychological and physical tests of his ability to fight injustice.\n\nSee more info [on IMDB](https://imdb.com/title/tt0468569)",
-                          "image": {
-                              "url": "https://m.media-amazon.com/images/M/MV5BMTMxNTMwODM0NF5BMl5BanBnXkFtZTcwODAyMTk2Mw@@._V1_.jpg"
-                          },
-                          "createdAt": "2022-01-17T05:00:58.423Z",
-                          "updatedAt": "2022-01-18T08:47:52.866Z",
-                          "publishedAt": "2022-01-17T05:01:00.594Z"
-                      }
-                  }
-              }
-          }
-      },
-      {
-          "id": 58,
-          "attributes": {
-              "start_time": "2022-02-07T17:00:00.000Z",
-              "room": "Stora salongen",
-              "createdAt": "2022-01-23T10:32:31.650Z",
-              "updatedAt": "2022-01-23T10:32:31.650Z",
-              "movie": {
-                  "data": {
-                      "id": 3,
-                      "attributes": {
-                          "title": "The Godfather: Part II",
-                          "imdbId": "tt0071562",
-                          "intro": "The early life and career of **Vito Corleone** in 1920s New York City is portrayed, while his son, **Michael**, expands and tightens his grip on the family crime syndicate.\n\nSee more info [on IMDB](https://imdb.com/title/tt0071562)",
-                          "image": {
-                              "url": "https://m.media-amazon.com/images/M/MV5BMWMwMGQzZTItY2JlNC00OWZiLWIyMDctNDk2ZDQ2YjRjMWQ0XkEyXkFqcGdeQXVyNzkwMjQ5NzM@._V1_.jpg"
-                          },
-                          "createdAt": "2022-01-17T05:00:31.562Z",
-                          "updatedAt": "2022-01-18T08:46:47.388Z",
-                          "publishedAt": "2022-01-17T05:00:33.453Z"
-                      }
-                  }
-              }
-          }
-      },
-      {
-          "id": 59,
-          "attributes": {
-              "start_time": "2022-02-07T19:00:00.000Z",
-              "room": "Stora salongen",
-              "createdAt": "2022-01-23T10:32:32.213Z",
-              "updatedAt": "2022-01-23T10:32:32.213Z",
-              "movie": {
-                  "data": {
-                      "id": 8,
-                      "attributes": {
-                          "title": "Idiocracy",
-                          "imdbId": "tt0387808",
-                          "intro": "Private **Joe Bauers**, a decisively average American, is selected as a guinea pig for a top-secret hibernation program but is forgotten, awakening to a future so incredibly moronic he's easily the most intelligent person alive.\n\nSee more info [on IMDB](https://imdb.com/title/tt0387808)",
-                          "image": {
-                              "url": "https://m.media-amazon.com/images/M/MV5BMWQ4MzI2ZDQtYjk3MS00ODdjLTkwN2QtOTBjYzIwM2RmNzgyXkEyXkFqcGdeQXVyMTQxNzMzNDI@._V1_.jpg"
-                          },
-                          "createdAt": "2022-01-17T09:32:08.570Z",
-                          "updatedAt": "2022-01-18T08:48:02.876Z",
-                          "publishedAt": "2022-01-17T09:32:12.868Z"
-                      }
-                  }
-              }
-          }
-      },
-      {
-          "id": 60,
-          "attributes": {
-              "start_time": "2022-02-07T21:00:00.000Z",
-              "room": "Stora salongen",
-              "createdAt": "2022-01-23T10:32:32.752Z",
-              "updatedAt": "2022-01-23T10:32:32.752Z",
-              "movie": {
-                  "data": {
-                      "id": 3,
-                      "attributes": {
-                          "title": "The Godfather: Part II",
-                          "imdbId": "tt0071562",
-                          "intro": "The early life and career of **Vito Corleone** in 1920s New York City is portrayed, while his son, **Michael**, expands and tightens his grip on the family crime syndicate.\n\nSee more info [on IMDB](https://imdb.com/title/tt0071562)",
-                          "image": {
-                              "url": "https://m.media-amazon.com/images/M/MV5BMWMwMGQzZTItY2JlNC00OWZiLWIyMDctNDk2ZDQ2YjRjMWQ0XkEyXkFqcGdeQXVyNzkwMjQ5NzM@._V1_.jpg"
-                          },
-                          "createdAt": "2022-01-17T05:00:31.562Z",
-                          "updatedAt": "2022-01-18T08:46:47.388Z",
-                          "publishedAt": "2022-01-17T05:00:33.453Z"
-                      }
-                  }
-              }
-          }
-      },
-      {
-          "id": 61,
-          "attributes": {
-              "start_time": "2022-02-08T12:00:00.000Z",
-              "room": "Stora salongen",
-              "createdAt": "2022-01-23T10:32:33.367Z",
-              "updatedAt": "2022-01-23T10:32:33.367Z",
-              "movie": {
-                  "data": {
-                      "id": 4,
-                      "attributes": {
-                          "title": "The Dark Knight",
-                          "imdbId": "tt0468569",
-                          "intro": "When the menace known as the Joker wreaks havoc and chaos on the people of Gotham, **Batman** must accept one of the greatest psychological and physical tests of his ability to fight injustice.\n\nSee more info [on IMDB](https://imdb.com/title/tt0468569)",
-                          "image": {
-                              "url": "https://m.media-amazon.com/images/M/MV5BMTMxNTMwODM0NF5BMl5BanBnXkFtZTcwODAyMTk2Mw@@._V1_.jpg"
-                          },
-                          "createdAt": "2022-01-17T05:00:58.423Z",
-                          "updatedAt": "2022-01-18T08:47:52.866Z",
-                          "publishedAt": "2022-01-17T05:01:00.594Z"
-                      }
-                  }
-              }
-          }
-      },
-      {
-          "id": 62,
-          "attributes": {
-              "start_time": "2022-02-08T17:00:00.000Z",
-              "room": "Stora salongen",
-              "createdAt": "2022-01-23T10:32:33.919Z",
-              "updatedAt": "2022-01-23T10:32:33.919Z",
-              "movie": {
-                  "data": {
-                      "id": 5,
-                      "attributes": {
-                          "title": "12 Angry Men",
-                          "imdbId": "tt0050083",
-                          "intro": "The jury in a New York City murder trial is frustrated by a single member whose skeptical caution forces them to more carefully consider the evidence before jumping to a hasty verdict.\n\nSee more info [on IMDB](https://imdb.com/title/tt0050083)",
-                          "image": {
-                              "url": "https://m.media-amazon.com/images/M/MV5BMWU4N2FjNzYtNTVkNC00NzQ0LTg0MjAtYTJlMjFhNGUxZDFmXkEyXkFqcGdeQXVyNjc1NTYyMjg@._V1_.jpg"
-                          },
-                          "createdAt": "2022-01-17T05:01:21.807Z",
-                          "updatedAt": "2022-01-18T08:48:15.429Z",
-                          "publishedAt": "2022-01-17T05:01:24.036Z"
-                      }
-                  }
-              }
-          }
-      },
-      {
-          "id": 63,
-          "attributes": {
-              "start_time": "2022-02-08T19:00:00.000Z",
-              "room": "Stora salongen",
-              "createdAt": "2022-01-23T10:32:34.469Z",
-              "updatedAt": "2022-01-23T10:32:34.469Z",
-              "movie": {
-                  "data": {
-                      "id": 10,
-                      "attributes": {
-                          "title": "Threat Level Midnight: The Movie",
-                          "imdbId": "tt11620828",
-                          "intro": "After secret agent **Michael Scarn** (played by Steve Carell) is forced into retirement due to the death of his wife **Catherine Zeta-Scarn**, the President of the United States of America (played by Craig Robinson) requests that he prevents **Goldenface** (played by John Krasinski) from blowing up the NHL All-Star Game and killing several hostages.\n\nSee more info [on IMDB](https://imdb.com/title/tt11620828)",
-                          "image": {
-                              "url": "https://m.media-amazon.com/images/M/MV5BZjMzNzE4ZGItMDI5Zi00ZjE3LThkODctYTlhZWY1ZTdmMGNjXkEyXkFqcGdeQXVyOTExNzM4NDM@._V1_.jpg"
-                          },
-                          "createdAt": "2022-01-17T10:51:45.145Z",
-                          "updatedAt": "2022-01-18T08:47:13.309Z",
-                          "publishedAt": "2022-01-17T10:51:53.355Z"
-                      }
-                  }
-              }
-          }
-      },
-      {
-          "id": 64,
-          "attributes": {
-              "start_time": "2022-02-08T21:00:00.000Z",
-              "room": "Stora salongen",
-              "createdAt": "2022-01-23T10:32:35.006Z",
-              "updatedAt": "2022-01-23T10:32:35.006Z",
-              "movie": {
-                  "data": {
-                      "id": 10,
-                      "attributes": {
-                          "title": "Threat Level Midnight: The Movie",
-                          "imdbId": "tt11620828",
-                          "intro": "After secret agent **Michael Scarn** (played by Steve Carell) is forced into retirement due to the death of his wife **Catherine Zeta-Scarn**, the President of the United States of America (played by Craig Robinson) requests that he prevents **Goldenface** (played by John Krasinski) from blowing up the NHL All-Star Game and killing several hostages.\n\nSee more info [on IMDB](https://imdb.com/title/tt11620828)",
-                          "image": {
-                              "url": "https://m.media-amazon.com/images/M/MV5BZjMzNzE4ZGItMDI5Zi00ZjE3LThkODctYTlhZWY1ZTdmMGNjXkEyXkFqcGdeQXVyOTExNzM4NDM@._V1_.jpg"
-                          },
-                          "createdAt": "2022-01-17T10:51:45.145Z",
-                          "updatedAt": "2022-01-18T08:47:13.309Z",
-                          "publishedAt": "2022-01-17T10:51:53.355Z"
-                      }
-                  }
-              }
-          }
-      },
-      {
-          "id": 65,
-          "attributes": {
-              "start_time": "2022-02-09T12:00:00.000Z",
-              "room": "Stora salongen",
-              "createdAt": "2022-01-23T10:32:35.544Z",
-              "updatedAt": "2022-01-23T10:32:35.544Z",
-              "movie": {
-                  "data": {
-                      "id": 10,
-                      "attributes": {
-                          "title": "Threat Level Midnight: The Movie",
-                          "imdbId": "tt11620828",
-                          "intro": "After secret agent **Michael Scarn** (played by Steve Carell) is forced into retirement due to the death of his wife **Catherine Zeta-Scarn**, the President of the United States of America (played by Craig Robinson) requests that he prevents **Goldenface** (played by John Krasinski) from blowing up the NHL All-Star Game and killing several hostages.\n\nSee more info [on IMDB](https://imdb.com/title/tt11620828)",
-                          "image": {
-                              "url": "https://m.media-amazon.com/images/M/MV5BZjMzNzE4ZGItMDI5Zi00ZjE3LThkODctYTlhZWY1ZTdmMGNjXkEyXkFqcGdeQXVyOTExNzM4NDM@._V1_.jpg"
-                          },
-                          "createdAt": "2022-01-17T10:51:45.145Z",
-                          "updatedAt": "2022-01-18T08:47:13.309Z",
-                          "publishedAt": "2022-01-17T10:51:53.355Z"
-                      }
-                  }
-              }
-          }
-      },
-      {
-          "id": 66,
-          "attributes": {
-              "start_time": "2022-02-09T17:00:00.000Z",
-              "room": "Stora salongen",
-              "createdAt": "2022-01-23T10:32:36.075Z",
-              "updatedAt": "2022-01-23T10:32:36.075Z",
-              "movie": {
-                  "data": {
-                      "id": 4,
-                      "attributes": {
-                          "title": "The Dark Knight",
-                          "imdbId": "tt0468569",
-                          "intro": "When the menace known as the Joker wreaks havoc and chaos on the people of Gotham, **Batman** must accept one of the greatest psychological and physical tests of his ability to fight injustice.\n\nSee more info [on IMDB](https://imdb.com/title/tt0468569)",
-                          "image": {
-                              "url": "https://m.media-amazon.com/images/M/MV5BMTMxNTMwODM0NF5BMl5BanBnXkFtZTcwODAyMTk2Mw@@._V1_.jpg"
-                          },
-                          "createdAt": "2022-01-17T05:00:58.423Z",
-                          "updatedAt": "2022-01-18T08:47:52.866Z",
-                          "publishedAt": "2022-01-17T05:01:00.594Z"
-                      }
-                  }
-              }
-          }
-      },
-      {
-          "id": 67,
-          "attributes": {
-              "start_time": "2022-02-09T19:00:00.000Z",
-              "room": "Stora salongen",
-              "createdAt": "2022-01-23T10:32:36.776Z",
-              "updatedAt": "2022-01-23T10:32:36.776Z",
-              "movie": {
-                  "data": {
-                      "id": 5,
-                      "attributes": {
-                          "title": "12 Angry Men",
-                          "imdbId": "tt0050083",
-                          "intro": "The jury in a New York City murder trial is frustrated by a single member whose skeptical caution forces them to more carefully consider the evidence before jumping to a hasty verdict.\n\nSee more info [on IMDB](https://imdb.com/title/tt0050083)",
-                          "image": {
-                              "url": "https://m.media-amazon.com/images/M/MV5BMWU4N2FjNzYtNTVkNC00NzQ0LTg0MjAtYTJlMjFhNGUxZDFmXkEyXkFqcGdeQXVyNjc1NTYyMjg@._V1_.jpg"
-                          },
-                          "createdAt": "2022-01-17T05:01:21.807Z",
-                          "updatedAt": "2022-01-18T08:48:15.429Z",
-                          "publishedAt": "2022-01-17T05:01:24.036Z"
-                      }
-                  }
-              }
-          }
-      },
-      {
-          "id": 68,
-          "attributes": {
-              "start_time": "2022-02-09T21:00:00.000Z",
-              "room": "Stora salongen",
-              "createdAt": "2022-01-23T10:32:37.605Z",
-              "updatedAt": "2022-01-23T10:32:37.605Z",
-              "movie": {
-                  "data": {
-                      "id": 1,
-                      "attributes": {
-                          "title": "The Shawshank Redemption",
-                          "imdbId": "tt0111161",
-                          "intro": "Two imprisoned men bond over a number of years, finding solace and eventual redemption through acts of common decency.\n\nSee more info [on IMDB](https://imdb.com/title/tt0111161)",
-                          "image": {
-                              "url": "https://m.media-amazon.com/images/M/MV5BMDFkYTc0MGEtZmNhMC00ZDIzLWFmNTEtODM1ZmRlYWMwMWFmXkEyXkFqcGdeQXVyMTMxODk2OTU@._V1_.jpg"
-                          },
-                          "createdAt": "2022-01-17T04:59:14.315Z",
-                          "updatedAt": "2022-01-18T08:47:01.417Z",
-                          "publishedAt": "2022-01-17T04:59:16.846Z"
-                      }
-                  }
-              }
-          }
-      },
-      {
-          "id": 69,
-          "attributes": {
-              "start_time": "2022-02-10T12:00:00.000Z",
-              "room": "Stora salongen",
-              "createdAt": "2022-01-23T10:32:38.433Z",
-              "updatedAt": "2022-01-23T10:32:38.433Z",
-              "movie": {
-                  "data": {
-                      "id": 5,
-                      "attributes": {
-                          "title": "12 Angry Men",
-                          "imdbId": "tt0050083",
-                          "intro": "The jury in a New York City murder trial is frustrated by a single member whose skeptical caution forces them to more carefully consider the evidence before jumping to a hasty verdict.\n\nSee more info [on IMDB](https://imdb.com/title/tt0050083)",
-                          "image": {
-                              "url": "https://m.media-amazon.com/images/M/MV5BMWU4N2FjNzYtNTVkNC00NzQ0LTg0MjAtYTJlMjFhNGUxZDFmXkEyXkFqcGdeQXVyNjc1NTYyMjg@._V1_.jpg"
-                          },
-                          "createdAt": "2022-01-17T05:01:21.807Z",
-                          "updatedAt": "2022-01-18T08:48:15.429Z",
-                          "publishedAt": "2022-01-17T05:01:24.036Z"
-                      }
-                  }
-              }
-          }
-      },
-      {
-          "id": 70,
-          "attributes": {
-              "start_time": "2022-02-10T17:00:00.000Z",
-              "room": "Stora salongen",
-              "createdAt": "2022-01-23T10:32:39.247Z",
-              "updatedAt": "2022-01-23T10:32:39.247Z",
-              "movie": {
-                  "data": {
-                      "id": 2,
-                      "attributes": {
-                          "title": "The Godfather",
-                          "imdbId": "tt0068646",
-                          "intro": "The Godfather follows **Vito Corleone**, Don of the Corleone family, as he passes the mantel to his unwilling son, **Michael**.\n\nSee more info [on IMDB](https://imdb.com/title/tt0068646)",
-                          "image": {
-                              "url": "https://m.media-amazon.com/images/M/MV5BM2MyNjYxNmUtYTAwNi00MTYxLWJmNWYtYzZlODY3ZTk3OTFlXkEyXkFqcGdeQXVyNzkwMjQ5NzM@._V1_.jpg"
-                          },
-                          "createdAt": "2022-01-17T04:59:42.763Z",
-                          "updatedAt": "2022-01-18T08:47:25.840Z",
-                          "publishedAt": "2022-01-17T04:59:44.929Z"
-                      }
-                  }
-              }
-          }
-      },
-      {
-          "id": 71,
-          "attributes": {
-              "start_time": "2022-02-10T19:00:00.000Z",
-              "room": "Stora salongen",
-              "createdAt": "2022-01-23T10:32:39.883Z",
-              "updatedAt": "2022-01-23T10:32:39.883Z",
-              "movie": {
-                  "data": {
-                      "id": 5,
-                      "attributes": {
-                          "title": "12 Angry Men",
-                          "imdbId": "tt0050083",
-                          "intro": "The jury in a New York City murder trial is frustrated by a single member whose skeptical caution forces them to more carefully consider the evidence before jumping to a hasty verdict.\n\nSee more info [on IMDB](https://imdb.com/title/tt0050083)",
-                          "image": {
-                              "url": "https://m.media-amazon.com/images/M/MV5BMWU4N2FjNzYtNTVkNC00NzQ0LTg0MjAtYTJlMjFhNGUxZDFmXkEyXkFqcGdeQXVyNjc1NTYyMjg@._V1_.jpg"
-                          },
-                          "createdAt": "2022-01-17T05:01:21.807Z",
-                          "updatedAt": "2022-01-18T08:48:15.429Z",
-                          "publishedAt": "2022-01-17T05:01:24.036Z"
-                      }
-                  }
-              }
-          }
-      },
-      {
-          "id": 72,
-          "attributes": {
-              "start_time": "2022-02-10T21:00:00.000Z",
-              "room": "Stora salongen",
-              "createdAt": "2022-01-23T10:32:40.408Z",
-              "updatedAt": "2022-01-23T10:32:40.408Z",
-              "movie": {
-                  "data": {
-                      "id": 10,
-                      "attributes": {
-                          "title": "Threat Level Midnight: The Movie",
-                          "imdbId": "tt11620828",
-                          "intro": "After secret agent **Michael Scarn** (played by Steve Carell) is forced into retirement due to the death of his wife **Catherine Zeta-Scarn**, the President of the United States of America (played by Craig Robinson) requests that he prevents **Goldenface** (played by John Krasinski) from blowing up the NHL All-Star Game and killing several hostages.\n\nSee more info [on IMDB](https://imdb.com/title/tt11620828)",
-                          "image": {
-                              "url": "https://m.media-amazon.com/images/M/MV5BZjMzNzE4ZGItMDI5Zi00ZjE3LThkODctYTlhZWY1ZTdmMGNjXkEyXkFqcGdeQXVyOTExNzM4NDM@._V1_.jpg"
-                          },
-                          "createdAt": "2022-01-17T10:51:45.145Z",
-                          "updatedAt": "2022-01-18T08:47:13.309Z",
-                          "publishedAt": "2022-01-17T10:51:53.355Z"
-                      }
-                  }
-              }
-          }
-      },
-      {
-          "id": 73,
-          "attributes": {
-              "start_time": "2022-02-11T12:00:00.000Z",
-              "room": "Stora salongen",
-              "createdAt": "2022-01-23T10:32:40.940Z",
-              "updatedAt": "2022-01-23T10:32:40.940Z",
-              "movie": {
-                  "data": {
-                      "id": 5,
-                      "attributes": {
-                          "title": "12 Angry Men",
-                          "imdbId": "tt0050083",
-                          "intro": "The jury in a New York City murder trial is frustrated by a single member whose skeptical caution forces them to more carefully consider the evidence before jumping to a hasty verdict.\n\nSee more info [on IMDB](https://imdb.com/title/tt0050083)",
-                          "image": {
-                              "url": "https://m.media-amazon.com/images/M/MV5BMWU4N2FjNzYtNTVkNC00NzQ0LTg0MjAtYTJlMjFhNGUxZDFmXkEyXkFqcGdeQXVyNjc1NTYyMjg@._V1_.jpg"
-                          },
-                          "createdAt": "2022-01-17T05:01:21.807Z",
-                          "updatedAt": "2022-01-18T08:48:15.429Z",
-                          "publishedAt": "2022-01-17T05:01:24.036Z"
-                      }
-                  }
-              }
-          }
-      },
-      {
-          "id": 74,
-          "attributes": {
-              "start_time": "2022-02-11T17:00:00.000Z",
-              "room": "Stora salongen",
-              "createdAt": "2022-01-23T10:32:41.527Z",
-              "updatedAt": "2022-01-23T10:32:41.527Z",
-              "movie": {
-                  "data": {
-                      "id": 2,
-                      "attributes": {
-                          "title": "The Godfather",
-                          "imdbId": "tt0068646",
-                          "intro": "The Godfather follows **Vito Corleone**, Don of the Corleone family, as he passes the mantel to his unwilling son, **Michael**.\n\nSee more info [on IMDB](https://imdb.com/title/tt0068646)",
-                          "image": {
-                              "url": "https://m.media-amazon.com/images/M/MV5BM2MyNjYxNmUtYTAwNi00MTYxLWJmNWYtYzZlODY3ZTk3OTFlXkEyXkFqcGdeQXVyNzkwMjQ5NzM@._V1_.jpg"
-                          },
-                          "createdAt": "2022-01-17T04:59:42.763Z",
-                          "updatedAt": "2022-01-18T08:47:25.840Z",
-                          "publishedAt": "2022-01-17T04:59:44.929Z"
-                      }
-                  }
-              }
-          }
-      },
-      {
-          "id": 75,
-          "attributes": {
-              "start_time": "2022-02-11T19:00:00.000Z",
-              "room": "Stora salongen",
-              "createdAt": "2022-01-23T10:32:42.401Z",
-              "updatedAt": "2022-01-23T10:32:42.401Z",
-              "movie": {
-                  "data": {
-                      "id": 3,
-                      "attributes": {
-                          "title": "The Godfather: Part II",
-                          "imdbId": "tt0071562",
-                          "intro": "The early life and career of **Vito Corleone** in 1920s New York City is portrayed, while his son, **Michael**, expands and tightens his grip on the family crime syndicate.\n\nSee more info [on IMDB](https://imdb.com/title/tt0071562)",
-                          "image": {
-                              "url": "https://m.media-amazon.com/images/M/MV5BMWMwMGQzZTItY2JlNC00OWZiLWIyMDctNDk2ZDQ2YjRjMWQ0XkEyXkFqcGdeQXVyNzkwMjQ5NzM@._V1_.jpg"
-                          },
-                          "createdAt": "2022-01-17T05:00:31.562Z",
-                          "updatedAt": "2022-01-18T08:46:47.388Z",
-                          "publishedAt": "2022-01-17T05:00:33.453Z"
-                      }
-                  }
-              }
-          }
-      },
-      {
-          "id": 76,
-          "attributes": {
-              "start_time": "2022-02-11T21:00:00.000Z",
-              "room": "Stora salongen",
-              "createdAt": "2022-01-23T10:32:42.953Z",
-              "updatedAt": "2022-01-23T10:32:42.953Z",
-              "movie": {
-                  "data": {
-                      "id": 5,
-                      "attributes": {
-                          "title": "12 Angry Men",
-                          "imdbId": "tt0050083",
-                          "intro": "The jury in a New York City murder trial is frustrated by a single member whose skeptical caution forces them to more carefully consider the evidence before jumping to a hasty verdict.\n\nSee more info [on IMDB](https://imdb.com/title/tt0050083)",
-                          "image": {
-                              "url": "https://m.media-amazon.com/images/M/MV5BMWU4N2FjNzYtNTVkNC00NzQ0LTg0MjAtYTJlMjFhNGUxZDFmXkEyXkFqcGdeQXVyNjc1NTYyMjg@._V1_.jpg"
-                          },
-                          "createdAt": "2022-01-17T05:01:21.807Z",
-                          "updatedAt": "2022-01-18T08:48:15.429Z",
-                          "publishedAt": "2022-01-17T05:01:24.036Z"
-                      }
-                  }
-              }
-          }
-      },
-      {
-          "id": 77,
-          "attributes": {
-              "start_time": "2022-02-12T12:00:00.000Z",
-              "room": "Stora salongen",
-              "createdAt": "2022-01-23T10:32:43.668Z",
-              "updatedAt": "2022-01-23T10:32:43.668Z",
-              "movie": {
-                  "data": {
-                      "id": 3,
-                      "attributes": {
-                          "title": "The Godfather: Part II",
-                          "imdbId": "tt0071562",
-                          "intro": "The early life and career of **Vito Corleone** in 1920s New York City is portrayed, while his son, **Michael**, expands and tightens his grip on the family crime syndicate.\n\nSee more info [on IMDB](https://imdb.com/title/tt0071562)",
-                          "image": {
-                              "url": "https://m.media-amazon.com/images/M/MV5BMWMwMGQzZTItY2JlNC00OWZiLWIyMDctNDk2ZDQ2YjRjMWQ0XkEyXkFqcGdeQXVyNzkwMjQ5NzM@._V1_.jpg"
-                          },
-                          "createdAt": "2022-01-17T05:00:31.562Z",
-                          "updatedAt": "2022-01-18T08:46:47.388Z",
-                          "publishedAt": "2022-01-17T05:00:33.453Z"
-                      }
-                  }
-              }
-          }
-      },
-      {
-          "id": 78,
-          "attributes": {
-              "start_time": "2022-02-12T17:00:00.000Z",
-              "room": "Stora salongen",
-              "createdAt": "2022-01-23T10:32:44.202Z",
-              "updatedAt": "2022-01-23T10:32:44.202Z",
-              "movie": {
-                  "data": {
-                      "id": 5,
-                      "attributes": {
-                          "title": "12 Angry Men",
-                          "imdbId": "tt0050083",
-                          "intro": "The jury in a New York City murder trial is frustrated by a single member whose skeptical caution forces them to more carefully consider the evidence before jumping to a hasty verdict.\n\nSee more info [on IMDB](https://imdb.com/title/tt0050083)",
-                          "image": {
-                              "url": "https://m.media-amazon.com/images/M/MV5BMWU4N2FjNzYtNTVkNC00NzQ0LTg0MjAtYTJlMjFhNGUxZDFmXkEyXkFqcGdeQXVyNjc1NTYyMjg@._V1_.jpg"
-                          },
-                          "createdAt": "2022-01-17T05:01:21.807Z",
-                          "updatedAt": "2022-01-18T08:48:15.429Z",
-                          "publishedAt": "2022-01-17T05:01:24.036Z"
-                      }
-                  }
-              }
-          }
-      },
-      {
-          "id": 79,
-          "attributes": {
-              "start_time": "2022-02-12T19:00:00.000Z",
-              "room": "Stora salongen",
-              "createdAt": "2022-01-23T10:32:44.767Z",
-              "updatedAt": "2022-01-23T10:32:44.767Z",
-              "movie": {
-                  "data": {
-                      "id": 10,
-                      "attributes": {
-                          "title": "Threat Level Midnight: The Movie",
-                          "imdbId": "tt11620828",
-                          "intro": "After secret agent **Michael Scarn** (played by Steve Carell) is forced into retirement due to the death of his wife **Catherine Zeta-Scarn**, the President of the United States of America (played by Craig Robinson) requests that he prevents **Goldenface** (played by John Krasinski) from blowing up the NHL All-Star Game and killing several hostages.\n\nSee more info [on IMDB](https://imdb.com/title/tt11620828)",
-                          "image": {
-                              "url": "https://m.media-amazon.com/images/M/MV5BZjMzNzE4ZGItMDI5Zi00ZjE3LThkODctYTlhZWY1ZTdmMGNjXkEyXkFqcGdeQXVyOTExNzM4NDM@._V1_.jpg"
-                          },
-                          "createdAt": "2022-01-17T10:51:45.145Z",
-                          "updatedAt": "2022-01-18T08:47:13.309Z",
-                          "publishedAt": "2022-01-17T10:51:53.355Z"
-                      }
-                  }
-              }
-          }
-      },
-      {
-          "id": 80,
-          "attributes": {
-              "start_time": "2022-02-12T21:00:00.000Z",
-              "room": "Stora salongen",
-              "createdAt": "2022-01-23T10:32:45.313Z",
-              "updatedAt": "2022-01-23T10:32:45.313Z",
-              "movie": {
-                  "data": {
-                      "id": 2,
-                      "attributes": {
-                          "title": "The Godfather",
-                          "imdbId": "tt0068646",
-                          "intro": "The Godfather follows **Vito Corleone**, Don of the Corleone family, as he passes the mantel to his unwilling son, **Michael**.\n\nSee more info [on IMDB](https://imdb.com/title/tt0068646)",
-                          "image": {
-                              "url": "https://m.media-amazon.com/images/M/MV5BM2MyNjYxNmUtYTAwNi00MTYxLWJmNWYtYzZlODY3ZTk3OTFlXkEyXkFqcGdeQXVyNzkwMjQ5NzM@._V1_.jpg"
-                          },
-                          "createdAt": "2022-01-17T04:59:42.763Z",
-                          "updatedAt": "2022-01-18T08:47:25.840Z",
-                          "publishedAt": "2022-01-17T04:59:44.929Z"
-                      }
-                  }
-              }
-          }
-      }
-  ];
+  {
+    id: 1,
+    attributes: {
+      start_time: '2022-01-24T12:00:00.000Z',
+      room: 'Stora salongen',
+      createdAt: '2022-01-23T10:31:58.536Z',
+      updatedAt: '2022-01-23T10:31:58.536Z',
+      movie: {
+        data: {
+          id: 10,
+          attributes: {
+            title: 'Threat Level Midnight: The Movie',
+            imdbId: 'tt11620828',
+            intro:
+              'After secret agent **Michael Scarn** (played by Steve Carell) is forced into retirement due to the death of his wife **Catherine Zeta-Scarn**, the President of the United States of America (played by Craig Robinson) requests that he prevents **Goldenface** (played by John Krasinski) from blowing up the NHL All-Star Game and killing several hostages.\n\nSee more info [on IMDB](https://imdb.com/title/tt11620828)',
+            image: {
+              url: 'https://m.media-amazon.com/images/M/MV5BZjMzNzE4ZGItMDI5Zi00ZjE3LThkODctYTlhZWY1ZTdmMGNjXkEyXkFqcGdeQXVyOTExNzM4NDM@._V1_.jpg',
+            },
+            createdAt: '2022-01-17T10:51:45.145Z',
+            updatedAt: '2022-01-18T08:47:13.309Z',
+            publishedAt: '2022-01-17T10:51:53.355Z',
+          },
+        },
+      },
+    },
+  },
+  {
+    id: 2,
+    attributes: {
+      start_time: '2022-01-24T17:00:00.000Z',
+      room: 'Stora salongen',
+      createdAt: '2022-01-23T10:31:59.065Z',
+      updatedAt: '2022-01-23T10:31:59.065Z',
+      movie: {
+        data: {
+          id: 8,
+          attributes: {
+            title: 'Idiocracy',
+            imdbId: 'tt0387808',
+            intro:
+              "Private **Joe Bauers**, a decisively average American, is selected as a guinea pig for a top-secret hibernation program but is forgotten, awakening to a future so incredibly moronic he's easily the most intelligent person alive.\n\nSee more info [on IMDB](https://imdb.com/title/tt0387808)",
+            image: {
+              url: 'https://m.media-amazon.com/images/M/MV5BMWQ4MzI2ZDQtYjk3MS00ODdjLTkwN2QtOTBjYzIwM2RmNzgyXkEyXkFqcGdeQXVyMTQxNzMzNDI@._V1_.jpg',
+            },
+            createdAt: '2022-01-17T09:32:08.570Z',
+            updatedAt: '2022-01-18T08:48:02.876Z',
+            publishedAt: '2022-01-17T09:32:12.868Z',
+          },
+        },
+      },
+    },
+  },
+  {
+    id: 3,
+    attributes: {
+      start_time: '2022-01-24T19:00:00.000Z',
+      room: 'Stora salongen',
+      createdAt: '2022-01-23T10:31:59.612Z',
+      updatedAt: '2022-01-23T10:31:59.612Z',
+      movie: {
+        data: {
+          id: 5,
+          attributes: {
+            title: '12 Angry Men',
+            imdbId: 'tt0050083',
+            intro:
+              'The jury in a New York City murder trial is frustrated by a single member whose skeptical caution forces them to more carefully consider the evidence before jumping to a hasty verdict.\n\nSee more info [on IMDB](https://imdb.com/title/tt0050083)',
+            image: {
+              url: 'https://m.media-amazon.com/images/M/MV5BMWU4N2FjNzYtNTVkNC00NzQ0LTg0MjAtYTJlMjFhNGUxZDFmXkEyXkFqcGdeQXVyNjc1NTYyMjg@._V1_.jpg',
+            },
+            createdAt: '2022-01-17T05:01:21.807Z',
+            updatedAt: '2022-01-18T08:48:15.429Z',
+            publishedAt: '2022-01-17T05:01:24.036Z',
+          },
+        },
+      },
+    },
+  },
+  {
+    id: 4,
+    attributes: {
+      start_time: '2022-01-24T21:00:00.000Z',
+      room: 'Stora salongen',
+      createdAt: '2022-01-23T10:32:00.277Z',
+      updatedAt: '2022-01-23T10:32:00.277Z',
+      movie: {
+        data: {
+          id: 5,
+          attributes: {
+            title: '12 Angry Men',
+            imdbId: 'tt0050083',
+            intro:
+              'The jury in a New York City murder trial is frustrated by a single member whose skeptical caution forces them to more carefully consider the evidence before jumping to a hasty verdict.\n\nSee more info [on IMDB](https://imdb.com/title/tt0050083)',
+            image: {
+              url: 'https://m.media-amazon.com/images/M/MV5BMWU4N2FjNzYtNTVkNC00NzQ0LTg0MjAtYTJlMjFhNGUxZDFmXkEyXkFqcGdeQXVyNjc1NTYyMjg@._V1_.jpg',
+            },
+            createdAt: '2022-01-17T05:01:21.807Z',
+            updatedAt: '2022-01-18T08:48:15.429Z',
+            publishedAt: '2022-01-17T05:01:24.036Z',
+          },
+        },
+      },
+    },
+  },
+  {
+    id: 5,
+    attributes: {
+      start_time: '2022-01-25T12:00:00.000Z',
+      room: 'Stora salongen',
+      createdAt: '2022-01-23T10:32:00.822Z',
+      updatedAt: '2022-01-23T10:32:00.822Z',
+      movie: {
+        data: {
+          id: 3,
+          attributes: {
+            title: 'The Godfather: Part II',
+            imdbId: 'tt0071562',
+            intro:
+              'The early life and career of **Vito Corleone** in 1920s New York City is portrayed, while his son, **Michael**, expands and tightens his grip on the family crime syndicate.\n\nSee more info [on IMDB](https://imdb.com/title/tt0071562)',
+            image: {
+              url: 'https://m.media-amazon.com/images/M/MV5BMWMwMGQzZTItY2JlNC00OWZiLWIyMDctNDk2ZDQ2YjRjMWQ0XkEyXkFqcGdeQXVyNzkwMjQ5NzM@._V1_.jpg',
+            },
+            createdAt: '2022-01-17T05:00:31.562Z',
+            updatedAt: '2022-01-18T08:46:47.388Z',
+            publishedAt: '2022-01-17T05:00:33.453Z',
+          },
+        },
+      },
+    },
+  },
+  {
+    id: 6,
+    attributes: {
+      start_time: '2022-01-25T17:00:00.000Z',
+      room: 'Stora salongen',
+      createdAt: '2022-01-23T10:32:01.366Z',
+      updatedAt: '2022-01-23T10:32:01.366Z',
+      movie: {
+        data: {
+          id: 3,
+          attributes: {
+            title: 'The Godfather: Part II',
+            imdbId: 'tt0071562',
+            intro:
+              'The early life and career of **Vito Corleone** in 1920s New York City is portrayed, while his son, **Michael**, expands and tightens his grip on the family crime syndicate.\n\nSee more info [on IMDB](https://imdb.com/title/tt0071562)',
+            image: {
+              url: 'https://m.media-amazon.com/images/M/MV5BMWMwMGQzZTItY2JlNC00OWZiLWIyMDctNDk2ZDQ2YjRjMWQ0XkEyXkFqcGdeQXVyNzkwMjQ5NzM@._V1_.jpg',
+            },
+            createdAt: '2022-01-17T05:00:31.562Z',
+            updatedAt: '2022-01-18T08:46:47.388Z',
+            publishedAt: '2022-01-17T05:00:33.453Z',
+          },
+        },
+      },
+    },
+  },
+  {
+    id: 7,
+    attributes: {
+      start_time: '2022-01-25T19:00:00.000Z',
+      room: 'Stora salongen',
+      createdAt: '2022-01-23T10:32:01.931Z',
+      updatedAt: '2022-01-23T10:32:01.931Z',
+      movie: {
+        data: {
+          id: 10,
+          attributes: {
+            title: 'Threat Level Midnight: The Movie',
+            imdbId: 'tt11620828',
+            intro:
+              'After secret agent **Michael Scarn** (played by Steve Carell) is forced into retirement due to the death of his wife **Catherine Zeta-Scarn**, the President of the United States of America (played by Craig Robinson) requests that he prevents **Goldenface** (played by John Krasinski) from blowing up the NHL All-Star Game and killing several hostages.\n\nSee more info [on IMDB](https://imdb.com/title/tt11620828)',
+            image: {
+              url: 'https://m.media-amazon.com/images/M/MV5BZjMzNzE4ZGItMDI5Zi00ZjE3LThkODctYTlhZWY1ZTdmMGNjXkEyXkFqcGdeQXVyOTExNzM4NDM@._V1_.jpg',
+            },
+            createdAt: '2022-01-17T10:51:45.145Z',
+            updatedAt: '2022-01-18T08:47:13.309Z',
+            publishedAt: '2022-01-17T10:51:53.355Z',
+          },
+        },
+      },
+    },
+  },
+  {
+    id: 8,
+    attributes: {
+      start_time: '2022-01-25T21:00:00.000Z',
+      room: 'Stora salongen',
+      createdAt: '2022-01-23T10:32:02.611Z',
+      updatedAt: '2022-01-23T10:32:02.611Z',
+      movie: {
+        data: {
+          id: 1,
+          attributes: {
+            title: 'The Shawshank Redemption',
+            imdbId: 'tt0111161',
+            intro:
+              'Two imprisoned men bond over a number of years, finding solace and eventual redemption through acts of common decency.\n\nSee more info [on IMDB](https://imdb.com/title/tt0111161)',
+            image: {
+              url: 'https://m.media-amazon.com/images/M/MV5BMDFkYTc0MGEtZmNhMC00ZDIzLWFmNTEtODM1ZmRlYWMwMWFmXkEyXkFqcGdeQXVyMTMxODk2OTU@._V1_.jpg',
+            },
+            createdAt: '2022-01-17T04:59:14.315Z',
+            updatedAt: '2022-01-18T08:47:01.417Z',
+            publishedAt: '2022-01-17T04:59:16.846Z',
+          },
+        },
+      },
+    },
+  },
+  {
+    id: 9,
+    attributes: {
+      start_time: '2022-01-26T12:00:00.000Z',
+      room: 'Stora salongen',
+      createdAt: '2022-01-23T10:32:03.180Z',
+      updatedAt: '2022-01-23T10:32:03.180Z',
+      movie: {
+        data: {
+          id: 5,
+          attributes: {
+            title: '12 Angry Men',
+            imdbId: 'tt0050083',
+            intro:
+              'The jury in a New York City murder trial is frustrated by a single member whose skeptical caution forces them to more carefully consider the evidence before jumping to a hasty verdict.\n\nSee more info [on IMDB](https://imdb.com/title/tt0050083)',
+            image: {
+              url: 'https://m.media-amazon.com/images/M/MV5BMWU4N2FjNzYtNTVkNC00NzQ0LTg0MjAtYTJlMjFhNGUxZDFmXkEyXkFqcGdeQXVyNjc1NTYyMjg@._V1_.jpg',
+            },
+            createdAt: '2022-01-17T05:01:21.807Z',
+            updatedAt: '2022-01-18T08:48:15.429Z',
+            publishedAt: '2022-01-17T05:01:24.036Z',
+          },
+        },
+      },
+    },
+  },
+  {
+    id: 10,
+    attributes: {
+      start_time: '2022-01-26T17:00:00.000Z',
+      room: 'Stora salongen',
+      createdAt: '2022-01-23T10:32:03.768Z',
+      updatedAt: '2022-01-23T10:32:03.768Z',
+      movie: {
+        data: {
+          id: 3,
+          attributes: {
+            title: 'The Godfather: Part II',
+            imdbId: 'tt0071562',
+            intro:
+              'The early life and career of **Vito Corleone** in 1920s New York City is portrayed, while his son, **Michael**, expands and tightens his grip on the family crime syndicate.\n\nSee more info [on IMDB](https://imdb.com/title/tt0071562)',
+            image: {
+              url: 'https://m.media-amazon.com/images/M/MV5BMWMwMGQzZTItY2JlNC00OWZiLWIyMDctNDk2ZDQ2YjRjMWQ0XkEyXkFqcGdeQXVyNzkwMjQ5NzM@._V1_.jpg',
+            },
+            createdAt: '2022-01-17T05:00:31.562Z',
+            updatedAt: '2022-01-18T08:46:47.388Z',
+            publishedAt: '2022-01-17T05:00:33.453Z',
+          },
+        },
+      },
+    },
+  },
+  {
+    id: 11,
+    attributes: {
+      start_time: '2022-01-26T19:00:00.000Z',
+      room: 'Stora salongen',
+      createdAt: '2022-01-23T10:32:04.326Z',
+      updatedAt: '2022-01-23T10:32:04.326Z',
+      movie: {
+        data: {
+          id: 10,
+          attributes: {
+            title: 'Threat Level Midnight: The Movie',
+            imdbId: 'tt11620828',
+            intro:
+              'After secret agent **Michael Scarn** (played by Steve Carell) is forced into retirement due to the death of his wife **Catherine Zeta-Scarn**, the President of the United States of America (played by Craig Robinson) requests that he prevents **Goldenface** (played by John Krasinski) from blowing up the NHL All-Star Game and killing several hostages.\n\nSee more info [on IMDB](https://imdb.com/title/tt11620828)',
+            image: {
+              url: 'https://m.media-amazon.com/images/M/MV5BZjMzNzE4ZGItMDI5Zi00ZjE3LThkODctYTlhZWY1ZTdmMGNjXkEyXkFqcGdeQXVyOTExNzM4NDM@._V1_.jpg',
+            },
+            createdAt: '2022-01-17T10:51:45.145Z',
+            updatedAt: '2022-01-18T08:47:13.309Z',
+            publishedAt: '2022-01-17T10:51:53.355Z',
+          },
+        },
+      },
+    },
+  },
+  {
+    id: 12,
+    attributes: {
+      start_time: '2022-01-26T21:00:00.000Z',
+      room: 'Stora salongen',
+      createdAt: '2022-01-23T10:32:05.168Z',
+      updatedAt: '2022-01-23T10:32:05.168Z',
+      movie: {
+        data: {
+          id: 2,
+          attributes: {
+            title: 'The Godfather',
+            imdbId: 'tt0068646',
+            intro:
+              'The Godfather follows **Vito Corleone**, Don of the Corleone family, as he passes the mantel to his unwilling son, **Michael**.\n\nSee more info [on IMDB](https://imdb.com/title/tt0068646)',
+            image: {
+              url: 'https://m.media-amazon.com/images/M/MV5BM2MyNjYxNmUtYTAwNi00MTYxLWJmNWYtYzZlODY3ZTk3OTFlXkEyXkFqcGdeQXVyNzkwMjQ5NzM@._V1_.jpg',
+            },
+            createdAt: '2022-01-17T04:59:42.763Z',
+            updatedAt: '2022-01-18T08:47:25.840Z',
+            publishedAt: '2022-01-17T04:59:44.929Z',
+          },
+        },
+      },
+    },
+  },
+  {
+    id: 13,
+    attributes: {
+      start_time: '2022-01-27T12:00:00.000Z',
+      room: 'Stora salongen',
+      createdAt: '2022-01-23T10:32:05.701Z',
+      updatedAt: '2022-01-23T10:32:05.701Z',
+      movie: {
+        data: {
+          id: 4,
+          attributes: {
+            title: 'The Dark Knight',
+            imdbId: 'tt0468569',
+            intro:
+              'When the menace known as the Joker wreaks havoc and chaos on the people of Gotham, **Batman** must accept one of the greatest psychological and physical tests of his ability to fight injustice.\n\nSee more info [on IMDB](https://imdb.com/title/tt0468569)',
+            image: {
+              url: 'https://m.media-amazon.com/images/M/MV5BMTMxNTMwODM0NF5BMl5BanBnXkFtZTcwODAyMTk2Mw@@._V1_.jpg',
+            },
+            createdAt: '2022-01-17T05:00:58.423Z',
+            updatedAt: '2022-01-18T08:47:52.866Z',
+            publishedAt: '2022-01-17T05:01:00.594Z',
+          },
+        },
+      },
+    },
+  },
+  {
+    id: 14,
+    attributes: {
+      start_time: '2022-01-27T17:00:00.000Z',
+      room: 'Stora salongen',
+      createdAt: '2022-01-23T10:32:06.233Z',
+      updatedAt: '2022-01-23T10:32:06.233Z',
+      movie: {
+        data: {
+          id: 8,
+          attributes: {
+            title: 'Idiocracy',
+            imdbId: 'tt0387808',
+            intro:
+              "Private **Joe Bauers**, a decisively average American, is selected as a guinea pig for a top-secret hibernation program but is forgotten, awakening to a future so incredibly moronic he's easily the most intelligent person alive.\n\nSee more info [on IMDB](https://imdb.com/title/tt0387808)",
+            image: {
+              url: 'https://m.media-amazon.com/images/M/MV5BMWQ4MzI2ZDQtYjk3MS00ODdjLTkwN2QtOTBjYzIwM2RmNzgyXkEyXkFqcGdeQXVyMTQxNzMzNDI@._V1_.jpg',
+            },
+            createdAt: '2022-01-17T09:32:08.570Z',
+            updatedAt: '2022-01-18T08:48:02.876Z',
+            publishedAt: '2022-01-17T09:32:12.868Z',
+          },
+        },
+      },
+    },
+  },
+  {
+    id: 15,
+    attributes: {
+      start_time: '2022-01-27T19:00:00.000Z',
+      room: 'Stora salongen',
+      createdAt: '2022-01-23T10:32:06.896Z',
+      updatedAt: '2022-01-23T10:32:06.896Z',
+      movie: {
+        data: {
+          id: 5,
+          attributes: {
+            title: '12 Angry Men',
+            imdbId: 'tt0050083',
+            intro:
+              'The jury in a New York City murder trial is frustrated by a single member whose skeptical caution forces them to more carefully consider the evidence before jumping to a hasty verdict.\n\nSee more info [on IMDB](https://imdb.com/title/tt0050083)',
+            image: {
+              url: 'https://m.media-amazon.com/images/M/MV5BMWU4N2FjNzYtNTVkNC00NzQ0LTg0MjAtYTJlMjFhNGUxZDFmXkEyXkFqcGdeQXVyNjc1NTYyMjg@._V1_.jpg',
+            },
+            createdAt: '2022-01-17T05:01:21.807Z',
+            updatedAt: '2022-01-18T08:48:15.429Z',
+            publishedAt: '2022-01-17T05:01:24.036Z',
+          },
+        },
+      },
+    },
+  },
+  {
+    id: 16,
+    attributes: {
+      start_time: '2022-01-27T21:00:00.000Z',
+      room: 'Stora salongen',
+      createdAt: '2022-01-23T10:32:07.444Z',
+      updatedAt: '2022-01-23T10:32:07.444Z',
+      movie: {
+        data: {
+          id: 5,
+          attributes: {
+            title: '12 Angry Men',
+            imdbId: 'tt0050083',
+            intro:
+              'The jury in a New York City murder trial is frustrated by a single member whose skeptical caution forces them to more carefully consider the evidence before jumping to a hasty verdict.\n\nSee more info [on IMDB](https://imdb.com/title/tt0050083)',
+            image: {
+              url: 'https://m.media-amazon.com/images/M/MV5BMWU4N2FjNzYtNTVkNC00NzQ0LTg0MjAtYTJlMjFhNGUxZDFmXkEyXkFqcGdeQXVyNjc1NTYyMjg@._V1_.jpg',
+            },
+            createdAt: '2022-01-17T05:01:21.807Z',
+            updatedAt: '2022-01-18T08:48:15.429Z',
+            publishedAt: '2022-01-17T05:01:24.036Z',
+          },
+        },
+      },
+    },
+  },
+  {
+    id: 17,
+    attributes: {
+      start_time: '2022-01-28T12:00:00.000Z',
+      room: 'Stora salongen',
+      createdAt: '2022-01-23T10:32:07.991Z',
+      updatedAt: '2022-01-23T10:32:07.991Z',
+      movie: {
+        data: {
+          id: 1,
+          attributes: {
+            title: 'The Shawshank Redemption',
+            imdbId: 'tt0111161',
+            intro:
+              'Two imprisoned men bond over a number of years, finding solace and eventual redemption through acts of common decency.\n\nSee more info [on IMDB](https://imdb.com/title/tt0111161)',
+            image: {
+              url: 'https://m.media-amazon.com/images/M/MV5BMDFkYTc0MGEtZmNhMC00ZDIzLWFmNTEtODM1ZmRlYWMwMWFmXkEyXkFqcGdeQXVyMTMxODk2OTU@._V1_.jpg',
+            },
+            createdAt: '2022-01-17T04:59:14.315Z',
+            updatedAt: '2022-01-18T08:47:01.417Z',
+            publishedAt: '2022-01-17T04:59:16.846Z',
+          },
+        },
+      },
+    },
+  },
+  {
+    id: 18,
+    attributes: {
+      start_time: '2022-01-28T17:00:00.000Z',
+      room: 'Stora salongen',
+      createdAt: '2022-01-23T10:32:08.517Z',
+      updatedAt: '2022-01-23T10:32:08.517Z',
+      movie: {
+        data: {
+          id: 1,
+          attributes: {
+            title: 'The Shawshank Redemption',
+            imdbId: 'tt0111161',
+            intro:
+              'Two imprisoned men bond over a number of years, finding solace and eventual redemption through acts of common decency.\n\nSee more info [on IMDB](https://imdb.com/title/tt0111161)',
+            image: {
+              url: 'https://m.media-amazon.com/images/M/MV5BMDFkYTc0MGEtZmNhMC00ZDIzLWFmNTEtODM1ZmRlYWMwMWFmXkEyXkFqcGdeQXVyMTMxODk2OTU@._V1_.jpg',
+            },
+            createdAt: '2022-01-17T04:59:14.315Z',
+            updatedAt: '2022-01-18T08:47:01.417Z',
+            publishedAt: '2022-01-17T04:59:16.846Z',
+          },
+        },
+      },
+    },
+  },
+  {
+    id: 19,
+    attributes: {
+      start_time: '2022-01-28T19:00:00.000Z',
+      room: 'Stora salongen',
+      createdAt: '2022-01-23T10:32:09.055Z',
+      updatedAt: '2022-01-23T10:32:09.055Z',
+      movie: {
+        data: {
+          id: 1,
+          attributes: {
+            title: 'The Shawshank Redemption',
+            imdbId: 'tt0111161',
+            intro:
+              'Two imprisoned men bond over a number of years, finding solace and eventual redemption through acts of common decency.\n\nSee more info [on IMDB](https://imdb.com/title/tt0111161)',
+            image: {
+              url: 'https://m.media-amazon.com/images/M/MV5BMDFkYTc0MGEtZmNhMC00ZDIzLWFmNTEtODM1ZmRlYWMwMWFmXkEyXkFqcGdeQXVyMTMxODk2OTU@._V1_.jpg',
+            },
+            createdAt: '2022-01-17T04:59:14.315Z',
+            updatedAt: '2022-01-18T08:47:01.417Z',
+            publishedAt: '2022-01-17T04:59:16.846Z',
+          },
+        },
+      },
+    },
+  },
+  {
+    id: 20,
+    attributes: {
+      start_time: '2022-01-28T21:00:00.000Z',
+      room: 'Stora salongen',
+      createdAt: '2022-01-23T10:32:09.591Z',
+      updatedAt: '2022-01-23T10:32:09.591Z',
+      movie: {
+        data: {
+          id: 2,
+          attributes: {
+            title: 'The Godfather',
+            imdbId: 'tt0068646',
+            intro:
+              'The Godfather follows **Vito Corleone**, Don of the Corleone family, as he passes the mantel to his unwilling son, **Michael**.\n\nSee more info [on IMDB](https://imdb.com/title/tt0068646)',
+            image: {
+              url: 'https://m.media-amazon.com/images/M/MV5BM2MyNjYxNmUtYTAwNi00MTYxLWJmNWYtYzZlODY3ZTk3OTFlXkEyXkFqcGdeQXVyNzkwMjQ5NzM@._V1_.jpg',
+            },
+            createdAt: '2022-01-17T04:59:42.763Z',
+            updatedAt: '2022-01-18T08:47:25.840Z',
+            publishedAt: '2022-01-17T04:59:44.929Z',
+          },
+        },
+      },
+    },
+  },
+  {
+    id: 21,
+    attributes: {
+      start_time: '2022-01-29T12:00:00.000Z',
+      room: 'Stora salongen',
+      createdAt: '2022-01-23T10:32:10.131Z',
+      updatedAt: '2022-01-23T10:32:10.131Z',
+      movie: {
+        data: {
+          id: 10,
+          attributes: {
+            title: 'Threat Level Midnight: The Movie',
+            imdbId: 'tt11620828',
+            intro:
+              'After secret agent **Michael Scarn** (played by Steve Carell) is forced into retirement due to the death of his wife **Catherine Zeta-Scarn**, the President of the United States of America (played by Craig Robinson) requests that he prevents **Goldenface** (played by John Krasinski) from blowing up the NHL All-Star Game and killing several hostages.\n\nSee more info [on IMDB](https://imdb.com/title/tt11620828)',
+            image: {
+              url: 'https://m.media-amazon.com/images/M/MV5BZjMzNzE4ZGItMDI5Zi00ZjE3LThkODctYTlhZWY1ZTdmMGNjXkEyXkFqcGdeQXVyOTExNzM4NDM@._V1_.jpg',
+            },
+            createdAt: '2022-01-17T10:51:45.145Z',
+            updatedAt: '2022-01-18T08:47:13.309Z',
+            publishedAt: '2022-01-17T10:51:53.355Z',
+          },
+        },
+      },
+    },
+  },
+  {
+    id: 22,
+    attributes: {
+      start_time: '2022-01-29T17:00:00.000Z',
+      room: 'Stora salongen',
+      createdAt: '2022-01-23T10:32:10.695Z',
+      updatedAt: '2022-01-23T10:32:10.695Z',
+      movie: {
+        data: {
+          id: 10,
+          attributes: {
+            title: 'Threat Level Midnight: The Movie',
+            imdbId: 'tt11620828',
+            intro:
+              'After secret agent **Michael Scarn** (played by Steve Carell) is forced into retirement due to the death of his wife **Catherine Zeta-Scarn**, the President of the United States of America (played by Craig Robinson) requests that he prevents **Goldenface** (played by John Krasinski) from blowing up the NHL All-Star Game and killing several hostages.\n\nSee more info [on IMDB](https://imdb.com/title/tt11620828)',
+            image: {
+              url: 'https://m.media-amazon.com/images/M/MV5BZjMzNzE4ZGItMDI5Zi00ZjE3LThkODctYTlhZWY1ZTdmMGNjXkEyXkFqcGdeQXVyOTExNzM4NDM@._V1_.jpg',
+            },
+            createdAt: '2022-01-17T10:51:45.145Z',
+            updatedAt: '2022-01-18T08:47:13.309Z',
+            publishedAt: '2022-01-17T10:51:53.355Z',
+          },
+        },
+      },
+    },
+  },
+  {
+    id: 23,
+    attributes: {
+      start_time: '2022-01-29T19:00:00.000Z',
+      room: 'Stora salongen',
+      createdAt: '2022-01-23T10:32:11.239Z',
+      updatedAt: '2022-01-23T10:32:11.239Z',
+      movie: {
+        data: {
+          id: 2,
+          attributes: {
+            title: 'The Godfather',
+            imdbId: 'tt0068646',
+            intro:
+              'The Godfather follows **Vito Corleone**, Don of the Corleone family, as he passes the mantel to his unwilling son, **Michael**.\n\nSee more info [on IMDB](https://imdb.com/title/tt0068646)',
+            image: {
+              url: 'https://m.media-amazon.com/images/M/MV5BM2MyNjYxNmUtYTAwNi00MTYxLWJmNWYtYzZlODY3ZTk3OTFlXkEyXkFqcGdeQXVyNzkwMjQ5NzM@._V1_.jpg',
+            },
+            createdAt: '2022-01-17T04:59:42.763Z',
+            updatedAt: '2022-01-18T08:47:25.840Z',
+            publishedAt: '2022-01-17T04:59:44.929Z',
+          },
+        },
+      },
+    },
+  },
+  {
+    id: 24,
+    attributes: {
+      start_time: '2022-01-29T21:00:00.000Z',
+      room: 'Stora salongen',
+      createdAt: '2022-01-23T10:32:11.766Z',
+      updatedAt: '2022-01-23T10:32:11.766Z',
+      movie: {
+        data: {
+          id: 1,
+          attributes: {
+            title: 'The Shawshank Redemption',
+            imdbId: 'tt0111161',
+            intro:
+              'Two imprisoned men bond over a number of years, finding solace and eventual redemption through acts of common decency.\n\nSee more info [on IMDB](https://imdb.com/title/tt0111161)',
+            image: {
+              url: 'https://m.media-amazon.com/images/M/MV5BMDFkYTc0MGEtZmNhMC00ZDIzLWFmNTEtODM1ZmRlYWMwMWFmXkEyXkFqcGdeQXVyMTMxODk2OTU@._V1_.jpg',
+            },
+            createdAt: '2022-01-17T04:59:14.315Z',
+            updatedAt: '2022-01-18T08:47:01.417Z',
+            publishedAt: '2022-01-17T04:59:16.846Z',
+          },
+        },
+      },
+    },
+  },
+  {
+    id: 25,
+    attributes: {
+      start_time: '2022-01-30T12:00:00.000Z',
+      room: 'Stora salongen',
+      createdAt: '2022-01-23T10:32:12.316Z',
+      updatedAt: '2022-01-23T10:32:12.316Z',
+      movie: {
+        data: {
+          id: 2,
+          attributes: {
+            title: 'The Godfather',
+            imdbId: 'tt0068646',
+            intro:
+              'The Godfather follows **Vito Corleone**, Don of the Corleone family, as he passes the mantel to his unwilling son, **Michael**.\n\nSee more info [on IMDB](https://imdb.com/title/tt0068646)',
+            image: {
+              url: 'https://m.media-amazon.com/images/M/MV5BM2MyNjYxNmUtYTAwNi00MTYxLWJmNWYtYzZlODY3ZTk3OTFlXkEyXkFqcGdeQXVyNzkwMjQ5NzM@._V1_.jpg',
+            },
+            createdAt: '2022-01-17T04:59:42.763Z',
+            updatedAt: '2022-01-18T08:47:25.840Z',
+            publishedAt: '2022-01-17T04:59:44.929Z',
+          },
+        },
+      },
+    },
+  },
+  {
+    id: 26,
+    attributes: {
+      start_time: '2022-01-30T17:00:00.000Z',
+      room: 'Stora salongen',
+      createdAt: '2022-01-23T10:32:12.918Z',
+      updatedAt: '2022-01-23T10:32:12.918Z',
+      movie: {
+        data: {
+          id: 2,
+          attributes: {
+            title: 'The Godfather',
+            imdbId: 'tt0068646',
+            intro:
+              'The Godfather follows **Vito Corleone**, Don of the Corleone family, as he passes the mantel to his unwilling son, **Michael**.\n\nSee more info [on IMDB](https://imdb.com/title/tt0068646)',
+            image: {
+              url: 'https://m.media-amazon.com/images/M/MV5BM2MyNjYxNmUtYTAwNi00MTYxLWJmNWYtYzZlODY3ZTk3OTFlXkEyXkFqcGdeQXVyNzkwMjQ5NzM@._V1_.jpg',
+            },
+            createdAt: '2022-01-17T04:59:42.763Z',
+            updatedAt: '2022-01-18T08:47:25.840Z',
+            publishedAt: '2022-01-17T04:59:44.929Z',
+          },
+        },
+      },
+    },
+  },
+  {
+    id: 27,
+    attributes: {
+      start_time: '2022-01-30T19:00:00.000Z',
+      room: 'Stora salongen',
+      createdAt: '2022-01-23T10:32:13.489Z',
+      updatedAt: '2022-01-23T10:32:13.489Z',
+      movie: {
+        data: {
+          id: 3,
+          attributes: {
+            title: 'The Godfather: Part II',
+            imdbId: 'tt0071562',
+            intro:
+              'The early life and career of **Vito Corleone** in 1920s New York City is portrayed, while his son, **Michael**, expands and tightens his grip on the family crime syndicate.\n\nSee more info [on IMDB](https://imdb.com/title/tt0071562)',
+            image: {
+              url: 'https://m.media-amazon.com/images/M/MV5BMWMwMGQzZTItY2JlNC00OWZiLWIyMDctNDk2ZDQ2YjRjMWQ0XkEyXkFqcGdeQXVyNzkwMjQ5NzM@._V1_.jpg',
+            },
+            createdAt: '2022-01-17T05:00:31.562Z',
+            updatedAt: '2022-01-18T08:46:47.388Z',
+            publishedAt: '2022-01-17T05:00:33.453Z',
+          },
+        },
+      },
+    },
+  },
+  {
+    id: 28,
+    attributes: {
+      start_time: '2022-01-30T21:00:00.000Z',
+      room: 'Stora salongen',
+      createdAt: '2022-01-23T10:32:14.039Z',
+      updatedAt: '2022-01-23T10:32:14.039Z',
+      movie: {
+        data: {
+          id: 2,
+          attributes: {
+            title: 'The Godfather',
+            imdbId: 'tt0068646',
+            intro:
+              'The Godfather follows **Vito Corleone**, Don of the Corleone family, as he passes the mantel to his unwilling son, **Michael**.\n\nSee more info [on IMDB](https://imdb.com/title/tt0068646)',
+            image: {
+              url: 'https://m.media-amazon.com/images/M/MV5BM2MyNjYxNmUtYTAwNi00MTYxLWJmNWYtYzZlODY3ZTk3OTFlXkEyXkFqcGdeQXVyNzkwMjQ5NzM@._V1_.jpg',
+            },
+            createdAt: '2022-01-17T04:59:42.763Z',
+            updatedAt: '2022-01-18T08:47:25.840Z',
+            publishedAt: '2022-01-17T04:59:44.929Z',
+          },
+        },
+      },
+    },
+  },
+  {
+    id: 29,
+    attributes: {
+      start_time: '2022-01-31T12:00:00.000Z',
+      room: 'Stora salongen',
+      createdAt: '2022-01-23T10:32:14.668Z',
+      updatedAt: '2022-01-23T10:32:14.668Z',
+      movie: {
+        data: {
+          id: 10,
+          attributes: {
+            title: 'Threat Level Midnight: The Movie',
+            imdbId: 'tt11620828',
+            intro:
+              'After secret agent **Michael Scarn** (played by Steve Carell) is forced into retirement due to the death of his wife **Catherine Zeta-Scarn**, the President of the United States of America (played by Craig Robinson) requests that he prevents **Goldenface** (played by John Krasinski) from blowing up the NHL All-Star Game and killing several hostages.\n\nSee more info [on IMDB](https://imdb.com/title/tt11620828)',
+            image: {
+              url: 'https://m.media-amazon.com/images/M/MV5BZjMzNzE4ZGItMDI5Zi00ZjE3LThkODctYTlhZWY1ZTdmMGNjXkEyXkFqcGdeQXVyOTExNzM4NDM@._V1_.jpg',
+            },
+            createdAt: '2022-01-17T10:51:45.145Z',
+            updatedAt: '2022-01-18T08:47:13.309Z',
+            publishedAt: '2022-01-17T10:51:53.355Z',
+          },
+        },
+      },
+    },
+  },
+  {
+    id: 30,
+    attributes: {
+      start_time: '2022-01-31T17:00:00.000Z',
+      room: 'Stora salongen',
+      createdAt: '2022-01-23T10:32:15.220Z',
+      updatedAt: '2022-01-23T10:32:15.220Z',
+      movie: {
+        data: {
+          id: 2,
+          attributes: {
+            title: 'The Godfather',
+            imdbId: 'tt0068646',
+            intro:
+              'The Godfather follows **Vito Corleone**, Don of the Corleone family, as he passes the mantel to his unwilling son, **Michael**.\n\nSee more info [on IMDB](https://imdb.com/title/tt0068646)',
+            image: {
+              url: 'https://m.media-amazon.com/images/M/MV5BM2MyNjYxNmUtYTAwNi00MTYxLWJmNWYtYzZlODY3ZTk3OTFlXkEyXkFqcGdeQXVyNzkwMjQ5NzM@._V1_.jpg',
+            },
+            createdAt: '2022-01-17T04:59:42.763Z',
+            updatedAt: '2022-01-18T08:47:25.840Z',
+            publishedAt: '2022-01-17T04:59:44.929Z',
+          },
+        },
+      },
+    },
+  },
+  {
+    id: 31,
+    attributes: {
+      start_time: '2022-01-31T19:00:00.000Z',
+      room: 'Stora salongen',
+      createdAt: '2022-01-23T10:32:15.771Z',
+      updatedAt: '2022-01-23T10:32:15.771Z',
+      movie: {
+        data: {
+          id: 4,
+          attributes: {
+            title: 'The Dark Knight',
+            imdbId: 'tt0468569',
+            intro:
+              'When the menace known as the Joker wreaks havoc and chaos on the people of Gotham, **Batman** must accept one of the greatest psychological and physical tests of his ability to fight injustice.\n\nSee more info [on IMDB](https://imdb.com/title/tt0468569)',
+            image: {
+              url: 'https://m.media-amazon.com/images/M/MV5BMTMxNTMwODM0NF5BMl5BanBnXkFtZTcwODAyMTk2Mw@@._V1_.jpg',
+            },
+            createdAt: '2022-01-17T05:00:58.423Z',
+            updatedAt: '2022-01-18T08:47:52.866Z',
+            publishedAt: '2022-01-17T05:01:00.594Z',
+          },
+        },
+      },
+    },
+  },
+  {
+    id: 32,
+    attributes: {
+      start_time: '2022-01-31T21:00:00.000Z',
+      room: 'Stora salongen',
+      createdAt: '2022-01-23T10:32:16.822Z',
+      updatedAt: '2022-01-23T10:32:16.822Z',
+      movie: {
+        data: {
+          id: 2,
+          attributes: {
+            title: 'The Godfather',
+            imdbId: 'tt0068646',
+            intro:
+              'The Godfather follows **Vito Corleone**, Don of the Corleone family, as he passes the mantel to his unwilling son, **Michael**.\n\nSee more info [on IMDB](https://imdb.com/title/tt0068646)',
+            image: {
+              url: 'https://m.media-amazon.com/images/M/MV5BM2MyNjYxNmUtYTAwNi00MTYxLWJmNWYtYzZlODY3ZTk3OTFlXkEyXkFqcGdeQXVyNzkwMjQ5NzM@._V1_.jpg',
+            },
+            createdAt: '2022-01-17T04:59:42.763Z',
+            updatedAt: '2022-01-18T08:47:25.840Z',
+            publishedAt: '2022-01-17T04:59:44.929Z',
+          },
+        },
+      },
+    },
+  },
+  {
+    id: 33,
+    attributes: {
+      start_time: '2022-02-01T12:00:00.000Z',
+      room: 'Stora salongen',
+      createdAt: '2022-01-23T10:32:17.391Z',
+      updatedAt: '2022-01-23T10:32:17.391Z',
+      movie: {
+        data: {
+          id: 8,
+          attributes: {
+            title: 'Idiocracy',
+            imdbId: 'tt0387808',
+            intro:
+              "Private **Joe Bauers**, a decisively average American, is selected as a guinea pig for a top-secret hibernation program but is forgotten, awakening to a future so incredibly moronic he's easily the most intelligent person alive.\n\nSee more info [on IMDB](https://imdb.com/title/tt0387808)",
+            image: {
+              url: 'https://m.media-amazon.com/images/M/MV5BMWQ4MzI2ZDQtYjk3MS00ODdjLTkwN2QtOTBjYzIwM2RmNzgyXkEyXkFqcGdeQXVyMTQxNzMzNDI@._V1_.jpg',
+            },
+            createdAt: '2022-01-17T09:32:08.570Z',
+            updatedAt: '2022-01-18T08:48:02.876Z',
+            publishedAt: '2022-01-17T09:32:12.868Z',
+          },
+        },
+      },
+    },
+  },
+  {
+    id: 34,
+    attributes: {
+      start_time: '2022-02-01T17:00:00.000Z',
+      room: 'Stora salongen',
+      createdAt: '2022-01-23T10:32:17.954Z',
+      updatedAt: '2022-01-23T10:32:17.954Z',
+      movie: {
+        data: {
+          id: 1,
+          attributes: {
+            title: 'The Shawshank Redemption',
+            imdbId: 'tt0111161',
+            intro:
+              'Two imprisoned men bond over a number of years, finding solace and eventual redemption through acts of common decency.\n\nSee more info [on IMDB](https://imdb.com/title/tt0111161)',
+            image: {
+              url: 'https://m.media-amazon.com/images/M/MV5BMDFkYTc0MGEtZmNhMC00ZDIzLWFmNTEtODM1ZmRlYWMwMWFmXkEyXkFqcGdeQXVyMTMxODk2OTU@._V1_.jpg',
+            },
+            createdAt: '2022-01-17T04:59:14.315Z',
+            updatedAt: '2022-01-18T08:47:01.417Z',
+            publishedAt: '2022-01-17T04:59:16.846Z',
+          },
+        },
+      },
+    },
+  },
+  {
+    id: 35,
+    attributes: {
+      start_time: '2022-02-01T19:00:00.000Z',
+      room: 'Stora salongen',
+      createdAt: '2022-01-23T10:32:18.516Z',
+      updatedAt: '2022-01-23T10:32:18.516Z',
+      movie: {
+        data: {
+          id: 3,
+          attributes: {
+            title: 'The Godfather: Part II',
+            imdbId: 'tt0071562',
+            intro:
+              'The early life and career of **Vito Corleone** in 1920s New York City is portrayed, while his son, **Michael**, expands and tightens his grip on the family crime syndicate.\n\nSee more info [on IMDB](https://imdb.com/title/tt0071562)',
+            image: {
+              url: 'https://m.media-amazon.com/images/M/MV5BMWMwMGQzZTItY2JlNC00OWZiLWIyMDctNDk2ZDQ2YjRjMWQ0XkEyXkFqcGdeQXVyNzkwMjQ5NzM@._V1_.jpg',
+            },
+            createdAt: '2022-01-17T05:00:31.562Z',
+            updatedAt: '2022-01-18T08:46:47.388Z',
+            publishedAt: '2022-01-17T05:00:33.453Z',
+          },
+        },
+      },
+    },
+  },
+  {
+    id: 36,
+    attributes: {
+      start_time: '2022-02-01T21:00:00.000Z',
+      room: 'Stora salongen',
+      createdAt: '2022-01-23T10:32:19.051Z',
+      updatedAt: '2022-01-23T10:32:19.051Z',
+      movie: {
+        data: {
+          id: 2,
+          attributes: {
+            title: 'The Godfather',
+            imdbId: 'tt0068646',
+            intro:
+              'The Godfather follows **Vito Corleone**, Don of the Corleone family, as he passes the mantel to his unwilling son, **Michael**.\n\nSee more info [on IMDB](https://imdb.com/title/tt0068646)',
+            image: {
+              url: 'https://m.media-amazon.com/images/M/MV5BM2MyNjYxNmUtYTAwNi00MTYxLWJmNWYtYzZlODY3ZTk3OTFlXkEyXkFqcGdeQXVyNzkwMjQ5NzM@._V1_.jpg',
+            },
+            createdAt: '2022-01-17T04:59:42.763Z',
+            updatedAt: '2022-01-18T08:47:25.840Z',
+            publishedAt: '2022-01-17T04:59:44.929Z',
+          },
+        },
+      },
+    },
+  },
+  {
+    id: 37,
+    attributes: {
+      start_time: '2022-02-02T12:00:00.000Z',
+      room: 'Stora salongen',
+      createdAt: '2022-01-23T10:32:19.612Z',
+      updatedAt: '2022-01-23T10:32:19.612Z',
+      movie: {
+        data: {
+          id: 8,
+          attributes: {
+            title: 'Idiocracy',
+            imdbId: 'tt0387808',
+            intro:
+              "Private **Joe Bauers**, a decisively average American, is selected as a guinea pig for a top-secret hibernation program but is forgotten, awakening to a future so incredibly moronic he's easily the most intelligent person alive.\n\nSee more info [on IMDB](https://imdb.com/title/tt0387808)",
+            image: {
+              url: 'https://m.media-amazon.com/images/M/MV5BMWQ4MzI2ZDQtYjk3MS00ODdjLTkwN2QtOTBjYzIwM2RmNzgyXkEyXkFqcGdeQXVyMTQxNzMzNDI@._V1_.jpg',
+            },
+            createdAt: '2022-01-17T09:32:08.570Z',
+            updatedAt: '2022-01-18T08:48:02.876Z',
+            publishedAt: '2022-01-17T09:32:12.868Z',
+          },
+        },
+      },
+    },
+  },
+  {
+    id: 38,
+    attributes: {
+      start_time: '2022-02-02T17:00:00.000Z',
+      room: 'Stora salongen',
+      createdAt: '2022-01-23T10:32:20.188Z',
+      updatedAt: '2022-01-23T10:32:20.188Z',
+      movie: {
+        data: {
+          id: 2,
+          attributes: {
+            title: 'The Godfather',
+            imdbId: 'tt0068646',
+            intro:
+              'The Godfather follows **Vito Corleone**, Don of the Corleone family, as he passes the mantel to his unwilling son, **Michael**.\n\nSee more info [on IMDB](https://imdb.com/title/tt0068646)',
+            image: {
+              url: 'https://m.media-amazon.com/images/M/MV5BM2MyNjYxNmUtYTAwNi00MTYxLWJmNWYtYzZlODY3ZTk3OTFlXkEyXkFqcGdeQXVyNzkwMjQ5NzM@._V1_.jpg',
+            },
+            createdAt: '2022-01-17T04:59:42.763Z',
+            updatedAt: '2022-01-18T08:47:25.840Z',
+            publishedAt: '2022-01-17T04:59:44.929Z',
+          },
+        },
+      },
+    },
+  },
+  {
+    id: 39,
+    attributes: {
+      start_time: '2022-02-02T19:00:00.000Z',
+      room: 'Stora salongen',
+      createdAt: '2022-01-23T10:32:20.722Z',
+      updatedAt: '2022-01-23T10:32:20.722Z',
+      movie: {
+        data: {
+          id: 4,
+          attributes: {
+            title: 'The Dark Knight',
+            imdbId: 'tt0468569',
+            intro:
+              'When the menace known as the Joker wreaks havoc and chaos on the people of Gotham, **Batman** must accept one of the greatest psychological and physical tests of his ability to fight injustice.\n\nSee more info [on IMDB](https://imdb.com/title/tt0468569)',
+            image: {
+              url: 'https://m.media-amazon.com/images/M/MV5BMTMxNTMwODM0NF5BMl5BanBnXkFtZTcwODAyMTk2Mw@@._V1_.jpg',
+            },
+            createdAt: '2022-01-17T05:00:58.423Z',
+            updatedAt: '2022-01-18T08:47:52.866Z',
+            publishedAt: '2022-01-17T05:01:00.594Z',
+          },
+        },
+      },
+    },
+  },
+  {
+    id: 40,
+    attributes: {
+      start_time: '2022-02-02T21:00:00.000Z',
+      room: 'Stora salongen',
+      createdAt: '2022-01-23T10:32:21.266Z',
+      updatedAt: '2022-01-23T10:32:21.266Z',
+      movie: {
+        data: {
+          id: 1,
+          attributes: {
+            title: 'The Shawshank Redemption',
+            imdbId: 'tt0111161',
+            intro:
+              'Two imprisoned men bond over a number of years, finding solace and eventual redemption through acts of common decency.\n\nSee more info [on IMDB](https://imdb.com/title/tt0111161)',
+            image: {
+              url: 'https://m.media-amazon.com/images/M/MV5BMDFkYTc0MGEtZmNhMC00ZDIzLWFmNTEtODM1ZmRlYWMwMWFmXkEyXkFqcGdeQXVyMTMxODk2OTU@._V1_.jpg',
+            },
+            createdAt: '2022-01-17T04:59:14.315Z',
+            updatedAt: '2022-01-18T08:47:01.417Z',
+            publishedAt: '2022-01-17T04:59:16.846Z',
+          },
+        },
+      },
+    },
+  },
+  {
+    id: 41,
+    attributes: {
+      start_time: '2022-02-03T12:00:00.000Z',
+      room: 'Stora salongen',
+      createdAt: '2022-01-23T10:32:21.864Z',
+      updatedAt: '2022-01-23T10:32:21.864Z',
+      movie: {
+        data: {
+          id: 1,
+          attributes: {
+            title: 'The Shawshank Redemption',
+            imdbId: 'tt0111161',
+            intro:
+              'Two imprisoned men bond over a number of years, finding solace and eventual redemption through acts of common decency.\n\nSee more info [on IMDB](https://imdb.com/title/tt0111161)',
+            image: {
+              url: 'https://m.media-amazon.com/images/M/MV5BMDFkYTc0MGEtZmNhMC00ZDIzLWFmNTEtODM1ZmRlYWMwMWFmXkEyXkFqcGdeQXVyMTMxODk2OTU@._V1_.jpg',
+            },
+            createdAt: '2022-01-17T04:59:14.315Z',
+            updatedAt: '2022-01-18T08:47:01.417Z',
+            publishedAt: '2022-01-17T04:59:16.846Z',
+          },
+        },
+      },
+    },
+  },
+  {
+    id: 42,
+    attributes: {
+      start_time: '2022-02-03T17:00:00.000Z',
+      room: 'Stora salongen',
+      createdAt: '2022-01-23T10:32:22.392Z',
+      updatedAt: '2022-01-23T10:32:22.392Z',
+      movie: {
+        data: {
+          id: 5,
+          attributes: {
+            title: '12 Angry Men',
+            imdbId: 'tt0050083',
+            intro:
+              'The jury in a New York City murder trial is frustrated by a single member whose skeptical caution forces them to more carefully consider the evidence before jumping to a hasty verdict.\n\nSee more info [on IMDB](https://imdb.com/title/tt0050083)',
+            image: {
+              url: 'https://m.media-amazon.com/images/M/MV5BMWU4N2FjNzYtNTVkNC00NzQ0LTg0MjAtYTJlMjFhNGUxZDFmXkEyXkFqcGdeQXVyNjc1NTYyMjg@._V1_.jpg',
+            },
+            createdAt: '2022-01-17T05:01:21.807Z',
+            updatedAt: '2022-01-18T08:48:15.429Z',
+            publishedAt: '2022-01-17T05:01:24.036Z',
+          },
+        },
+      },
+    },
+  },
+  {
+    id: 43,
+    attributes: {
+      start_time: '2022-02-03T19:00:00.000Z',
+      room: 'Stora salongen',
+      createdAt: '2022-01-23T10:32:22.955Z',
+      updatedAt: '2022-01-23T10:32:22.955Z',
+      movie: {
+        data: {
+          id: 2,
+          attributes: {
+            title: 'The Godfather',
+            imdbId: 'tt0068646',
+            intro:
+              'The Godfather follows **Vito Corleone**, Don of the Corleone family, as he passes the mantel to his unwilling son, **Michael**.\n\nSee more info [on IMDB](https://imdb.com/title/tt0068646)',
+            image: {
+              url: 'https://m.media-amazon.com/images/M/MV5BM2MyNjYxNmUtYTAwNi00MTYxLWJmNWYtYzZlODY3ZTk3OTFlXkEyXkFqcGdeQXVyNzkwMjQ5NzM@._V1_.jpg',
+            },
+            createdAt: '2022-01-17T04:59:42.763Z',
+            updatedAt: '2022-01-18T08:47:25.840Z',
+            publishedAt: '2022-01-17T04:59:44.929Z',
+          },
+        },
+      },
+    },
+  },
+  {
+    id: 44,
+    attributes: {
+      start_time: '2022-02-03T21:00:00.000Z',
+      room: 'Stora salongen',
+      createdAt: '2022-01-23T10:32:23.740Z',
+      updatedAt: '2022-01-23T10:32:23.740Z',
+      movie: {
+        data: {
+          id: 3,
+          attributes: {
+            title: 'The Godfather: Part II',
+            imdbId: 'tt0071562',
+            intro:
+              'The early life and career of **Vito Corleone** in 1920s New York City is portrayed, while his son, **Michael**, expands and tightens his grip on the family crime syndicate.\n\nSee more info [on IMDB](https://imdb.com/title/tt0071562)',
+            image: {
+              url: 'https://m.media-amazon.com/images/M/MV5BMWMwMGQzZTItY2JlNC00OWZiLWIyMDctNDk2ZDQ2YjRjMWQ0XkEyXkFqcGdeQXVyNzkwMjQ5NzM@._V1_.jpg',
+            },
+            createdAt: '2022-01-17T05:00:31.562Z',
+            updatedAt: '2022-01-18T08:46:47.388Z',
+            publishedAt: '2022-01-17T05:00:33.453Z',
+          },
+        },
+      },
+    },
+  },
+  {
+    id: 45,
+    attributes: {
+      start_time: '2022-02-04T12:00:00.000Z',
+      room: 'Stora salongen',
+      createdAt: '2022-01-23T10:32:24.272Z',
+      updatedAt: '2022-01-23T10:32:24.272Z',
+      movie: {
+        data: {
+          id: 5,
+          attributes: {
+            title: '12 Angry Men',
+            imdbId: 'tt0050083',
+            intro:
+              'The jury in a New York City murder trial is frustrated by a single member whose skeptical caution forces them to more carefully consider the evidence before jumping to a hasty verdict.\n\nSee more info [on IMDB](https://imdb.com/title/tt0050083)',
+            image: {
+              url: 'https://m.media-amazon.com/images/M/MV5BMWU4N2FjNzYtNTVkNC00NzQ0LTg0MjAtYTJlMjFhNGUxZDFmXkEyXkFqcGdeQXVyNjc1NTYyMjg@._V1_.jpg',
+            },
+            createdAt: '2022-01-17T05:01:21.807Z',
+            updatedAt: '2022-01-18T08:48:15.429Z',
+            publishedAt: '2022-01-17T05:01:24.036Z',
+          },
+        },
+      },
+    },
+  },
+  {
+    id: 46,
+    attributes: {
+      start_time: '2022-02-04T17:00:00.000Z',
+      room: 'Stora salongen',
+      createdAt: '2022-01-23T10:32:24.811Z',
+      updatedAt: '2022-01-23T10:32:24.811Z',
+      movie: {
+        data: {
+          id: 3,
+          attributes: {
+            title: 'The Godfather: Part II',
+            imdbId: 'tt0071562',
+            intro:
+              'The early life and career of **Vito Corleone** in 1920s New York City is portrayed, while his son, **Michael**, expands and tightens his grip on the family crime syndicate.\n\nSee more info [on IMDB](https://imdb.com/title/tt0071562)',
+            image: {
+              url: 'https://m.media-amazon.com/images/M/MV5BMWMwMGQzZTItY2JlNC00OWZiLWIyMDctNDk2ZDQ2YjRjMWQ0XkEyXkFqcGdeQXVyNzkwMjQ5NzM@._V1_.jpg',
+            },
+            createdAt: '2022-01-17T05:00:31.562Z',
+            updatedAt: '2022-01-18T08:46:47.388Z',
+            publishedAt: '2022-01-17T05:00:33.453Z',
+          },
+        },
+      },
+    },
+  },
+  {
+    id: 47,
+    attributes: {
+      start_time: '2022-02-04T19:00:00.000Z',
+      room: 'Stora salongen',
+      createdAt: '2022-01-23T10:32:25.382Z',
+      updatedAt: '2022-01-23T10:32:25.382Z',
+      movie: {
+        data: {
+          id: 1,
+          attributes: {
+            title: 'The Shawshank Redemption',
+            imdbId: 'tt0111161',
+            intro:
+              'Two imprisoned men bond over a number of years, finding solace and eventual redemption through acts of common decency.\n\nSee more info [on IMDB](https://imdb.com/title/tt0111161)',
+            image: {
+              url: 'https://m.media-amazon.com/images/M/MV5BMDFkYTc0MGEtZmNhMC00ZDIzLWFmNTEtODM1ZmRlYWMwMWFmXkEyXkFqcGdeQXVyMTMxODk2OTU@._V1_.jpg',
+            },
+            createdAt: '2022-01-17T04:59:14.315Z',
+            updatedAt: '2022-01-18T08:47:01.417Z',
+            publishedAt: '2022-01-17T04:59:16.846Z',
+          },
+        },
+      },
+    },
+  },
+  {
+    id: 48,
+    attributes: {
+      start_time: '2022-02-04T21:00:00.000Z',
+      room: 'Stora salongen',
+      createdAt: '2022-01-23T10:32:25.918Z',
+      updatedAt: '2022-01-23T10:32:25.918Z',
+      movie: {
+        data: {
+          id: 4,
+          attributes: {
+            title: 'The Dark Knight',
+            imdbId: 'tt0468569',
+            intro:
+              'When the menace known as the Joker wreaks havoc and chaos on the people of Gotham, **Batman** must accept one of the greatest psychological and physical tests of his ability to fight injustice.\n\nSee more info [on IMDB](https://imdb.com/title/tt0468569)',
+            image: {
+              url: 'https://m.media-amazon.com/images/M/MV5BMTMxNTMwODM0NF5BMl5BanBnXkFtZTcwODAyMTk2Mw@@._V1_.jpg',
+            },
+            createdAt: '2022-01-17T05:00:58.423Z',
+            updatedAt: '2022-01-18T08:47:52.866Z',
+            publishedAt: '2022-01-17T05:01:00.594Z',
+          },
+        },
+      },
+    },
+  },
+  {
+    id: 49,
+    attributes: {
+      start_time: '2022-02-05T12:00:00.000Z',
+      room: 'Stora salongen',
+      createdAt: '2022-01-23T10:32:26.441Z',
+      updatedAt: '2022-01-23T10:32:26.441Z',
+      movie: {
+        data: {
+          id: 5,
+          attributes: {
+            title: '12 Angry Men',
+            imdbId: 'tt0050083',
+            intro:
+              'The jury in a New York City murder trial is frustrated by a single member whose skeptical caution forces them to more carefully consider the evidence before jumping to a hasty verdict.\n\nSee more info [on IMDB](https://imdb.com/title/tt0050083)',
+            image: {
+              url: 'https://m.media-amazon.com/images/M/MV5BMWU4N2FjNzYtNTVkNC00NzQ0LTg0MjAtYTJlMjFhNGUxZDFmXkEyXkFqcGdeQXVyNjc1NTYyMjg@._V1_.jpg',
+            },
+            createdAt: '2022-01-17T05:01:21.807Z',
+            updatedAt: '2022-01-18T08:48:15.429Z',
+            publishedAt: '2022-01-17T05:01:24.036Z',
+          },
+        },
+      },
+    },
+  },
+  {
+    id: 50,
+    attributes: {
+      start_time: '2022-02-05T17:00:00.000Z',
+      room: 'Stora salongen',
+      createdAt: '2022-01-23T10:32:26.971Z',
+      updatedAt: '2022-01-23T10:32:26.971Z',
+      movie: {
+        data: {
+          id: 8,
+          attributes: {
+            title: 'Idiocracy',
+            imdbId: 'tt0387808',
+            intro:
+              "Private **Joe Bauers**, a decisively average American, is selected as a guinea pig for a top-secret hibernation program but is forgotten, awakening to a future so incredibly moronic he's easily the most intelligent person alive.\n\nSee more info [on IMDB](https://imdb.com/title/tt0387808)",
+            image: {
+              url: 'https://m.media-amazon.com/images/M/MV5BMWQ4MzI2ZDQtYjk3MS00ODdjLTkwN2QtOTBjYzIwM2RmNzgyXkEyXkFqcGdeQXVyMTQxNzMzNDI@._V1_.jpg',
+            },
+            createdAt: '2022-01-17T09:32:08.570Z',
+            updatedAt: '2022-01-18T08:48:02.876Z',
+            publishedAt: '2022-01-17T09:32:12.868Z',
+          },
+        },
+      },
+    },
+  },
+  {
+    id: 51,
+    attributes: {
+      start_time: '2022-02-05T19:00:00.000Z',
+      room: 'Stora salongen',
+      createdAt: '2022-01-23T10:32:27.507Z',
+      updatedAt: '2022-01-23T10:32:27.507Z',
+      movie: {
+        data: {
+          id: 10,
+          attributes: {
+            title: 'Threat Level Midnight: The Movie',
+            imdbId: 'tt11620828',
+            intro:
+              'After secret agent **Michael Scarn** (played by Steve Carell) is forced into retirement due to the death of his wife **Catherine Zeta-Scarn**, the President of the United States of America (played by Craig Robinson) requests that he prevents **Goldenface** (played by John Krasinski) from blowing up the NHL All-Star Game and killing several hostages.\n\nSee more info [on IMDB](https://imdb.com/title/tt11620828)',
+            image: {
+              url: 'https://m.media-amazon.com/images/M/MV5BZjMzNzE4ZGItMDI5Zi00ZjE3LThkODctYTlhZWY1ZTdmMGNjXkEyXkFqcGdeQXVyOTExNzM4NDM@._V1_.jpg',
+            },
+            createdAt: '2022-01-17T10:51:45.145Z',
+            updatedAt: '2022-01-18T08:47:13.309Z',
+            publishedAt: '2022-01-17T10:51:53.355Z',
+          },
+        },
+      },
+    },
+  },
+  {
+    id: 52,
+    attributes: {
+      start_time: '2022-02-05T21:00:00.000Z',
+      room: 'Stora salongen',
+      createdAt: '2022-01-23T10:32:28.083Z',
+      updatedAt: '2022-01-23T10:32:28.083Z',
+      movie: {
+        data: {
+          id: 4,
+          attributes: {
+            title: 'The Dark Knight',
+            imdbId: 'tt0468569',
+            intro:
+              'When the menace known as the Joker wreaks havoc and chaos on the people of Gotham, **Batman** must accept one of the greatest psychological and physical tests of his ability to fight injustice.\n\nSee more info [on IMDB](https://imdb.com/title/tt0468569)',
+            image: {
+              url: 'https://m.media-amazon.com/images/M/MV5BMTMxNTMwODM0NF5BMl5BanBnXkFtZTcwODAyMTk2Mw@@._V1_.jpg',
+            },
+            createdAt: '2022-01-17T05:00:58.423Z',
+            updatedAt: '2022-01-18T08:47:52.866Z',
+            publishedAt: '2022-01-17T05:01:00.594Z',
+          },
+        },
+      },
+    },
+  },
+  {
+    id: 53,
+    attributes: {
+      start_time: '2022-02-06T12:00:00.000Z',
+      room: 'Stora salongen',
+      createdAt: '2022-01-23T10:32:28.663Z',
+      updatedAt: '2022-01-23T10:32:28.663Z',
+      movie: {
+        data: {
+          id: 5,
+          attributes: {
+            title: '12 Angry Men',
+            imdbId: 'tt0050083',
+            intro:
+              'The jury in a New York City murder trial is frustrated by a single member whose skeptical caution forces them to more carefully consider the evidence before jumping to a hasty verdict.\n\nSee more info [on IMDB](https://imdb.com/title/tt0050083)',
+            image: {
+              url: 'https://m.media-amazon.com/images/M/MV5BMWU4N2FjNzYtNTVkNC00NzQ0LTg0MjAtYTJlMjFhNGUxZDFmXkEyXkFqcGdeQXVyNjc1NTYyMjg@._V1_.jpg',
+            },
+            createdAt: '2022-01-17T05:01:21.807Z',
+            updatedAt: '2022-01-18T08:48:15.429Z',
+            publishedAt: '2022-01-17T05:01:24.036Z',
+          },
+        },
+      },
+    },
+  },
+  {
+    id: 54,
+    attributes: {
+      start_time: '2022-02-06T17:00:00.000Z',
+      room: 'Stora salongen',
+      createdAt: '2022-01-23T10:32:29.220Z',
+      updatedAt: '2022-01-23T10:32:29.220Z',
+      movie: {
+        data: {
+          id: 4,
+          attributes: {
+            title: 'The Dark Knight',
+            imdbId: 'tt0468569',
+            intro:
+              'When the menace known as the Joker wreaks havoc and chaos on the people of Gotham, **Batman** must accept one of the greatest psychological and physical tests of his ability to fight injustice.\n\nSee more info [on IMDB](https://imdb.com/title/tt0468569)',
+            image: {
+              url: 'https://m.media-amazon.com/images/M/MV5BMTMxNTMwODM0NF5BMl5BanBnXkFtZTcwODAyMTk2Mw@@._V1_.jpg',
+            },
+            createdAt: '2022-01-17T05:00:58.423Z',
+            updatedAt: '2022-01-18T08:47:52.866Z',
+            publishedAt: '2022-01-17T05:01:00.594Z',
+          },
+        },
+      },
+    },
+  },
+  {
+    id: 55,
+    attributes: {
+      start_time: '2022-02-06T19:00:00.000Z',
+      room: 'Stora salongen',
+      createdAt: '2022-01-23T10:32:30.046Z',
+      updatedAt: '2022-01-23T10:32:30.046Z',
+      movie: {
+        data: {
+          id: 5,
+          attributes: {
+            title: '12 Angry Men',
+            imdbId: 'tt0050083',
+            intro:
+              'The jury in a New York City murder trial is frustrated by a single member whose skeptical caution forces them to more carefully consider the evidence before jumping to a hasty verdict.\n\nSee more info [on IMDB](https://imdb.com/title/tt0050083)',
+            image: {
+              url: 'https://m.media-amazon.com/images/M/MV5BMWU4N2FjNzYtNTVkNC00NzQ0LTg0MjAtYTJlMjFhNGUxZDFmXkEyXkFqcGdeQXVyNjc1NTYyMjg@._V1_.jpg',
+            },
+            createdAt: '2022-01-17T05:01:21.807Z',
+            updatedAt: '2022-01-18T08:48:15.429Z',
+            publishedAt: '2022-01-17T05:01:24.036Z',
+          },
+        },
+      },
+    },
+  },
+  {
+    id: 56,
+    attributes: {
+      start_time: '2022-02-06T21:00:00.000Z',
+      room: 'Stora salongen',
+      createdAt: '2022-01-23T10:32:30.580Z',
+      updatedAt: '2022-01-23T10:32:30.580Z',
+      movie: {
+        data: {
+          id: 3,
+          attributes: {
+            title: 'The Godfather: Part II',
+            imdbId: 'tt0071562',
+            intro:
+              'The early life and career of **Vito Corleone** in 1920s New York City is portrayed, while his son, **Michael**, expands and tightens his grip on the family crime syndicate.\n\nSee more info [on IMDB](https://imdb.com/title/tt0071562)',
+            image: {
+              url: 'https://m.media-amazon.com/images/M/MV5BMWMwMGQzZTItY2JlNC00OWZiLWIyMDctNDk2ZDQ2YjRjMWQ0XkEyXkFqcGdeQXVyNzkwMjQ5NzM@._V1_.jpg',
+            },
+            createdAt: '2022-01-17T05:00:31.562Z',
+            updatedAt: '2022-01-18T08:46:47.388Z',
+            publishedAt: '2022-01-17T05:00:33.453Z',
+          },
+        },
+      },
+    },
+  },
+  {
+    id: 57,
+    attributes: {
+      start_time: '2022-02-07T12:00:00.000Z',
+      room: 'Stora salongen',
+      createdAt: '2022-01-23T10:32:31.119Z',
+      updatedAt: '2022-01-23T10:32:31.119Z',
+      movie: {
+        data: {
+          id: 4,
+          attributes: {
+            title: 'The Dark Knight',
+            imdbId: 'tt0468569',
+            intro:
+              'When the menace known as the Joker wreaks havoc and chaos on the people of Gotham, **Batman** must accept one of the greatest psychological and physical tests of his ability to fight injustice.\n\nSee more info [on IMDB](https://imdb.com/title/tt0468569)',
+            image: {
+              url: 'https://m.media-amazon.com/images/M/MV5BMTMxNTMwODM0NF5BMl5BanBnXkFtZTcwODAyMTk2Mw@@._V1_.jpg',
+            },
+            createdAt: '2022-01-17T05:00:58.423Z',
+            updatedAt: '2022-01-18T08:47:52.866Z',
+            publishedAt: '2022-01-17T05:01:00.594Z',
+          },
+        },
+      },
+    },
+  },
+  {
+    id: 58,
+    attributes: {
+      start_time: '2022-02-07T17:00:00.000Z',
+      room: 'Stora salongen',
+      createdAt: '2022-01-23T10:32:31.650Z',
+      updatedAt: '2022-01-23T10:32:31.650Z',
+      movie: {
+        data: {
+          id: 3,
+          attributes: {
+            title: 'The Godfather: Part II',
+            imdbId: 'tt0071562',
+            intro:
+              'The early life and career of **Vito Corleone** in 1920s New York City is portrayed, while his son, **Michael**, expands and tightens his grip on the family crime syndicate.\n\nSee more info [on IMDB](https://imdb.com/title/tt0071562)',
+            image: {
+              url: 'https://m.media-amazon.com/images/M/MV5BMWMwMGQzZTItY2JlNC00OWZiLWIyMDctNDk2ZDQ2YjRjMWQ0XkEyXkFqcGdeQXVyNzkwMjQ5NzM@._V1_.jpg',
+            },
+            createdAt: '2022-01-17T05:00:31.562Z',
+            updatedAt: '2022-01-18T08:46:47.388Z',
+            publishedAt: '2022-01-17T05:00:33.453Z',
+          },
+        },
+      },
+    },
+  },
+  {
+    id: 59,
+    attributes: {
+      start_time: '2022-02-07T19:00:00.000Z',
+      room: 'Stora salongen',
+      createdAt: '2022-01-23T10:32:32.213Z',
+      updatedAt: '2022-01-23T10:32:32.213Z',
+      movie: {
+        data: {
+          id: 8,
+          attributes: {
+            title: 'Idiocracy',
+            imdbId: 'tt0387808',
+            intro:
+              "Private **Joe Bauers**, a decisively average American, is selected as a guinea pig for a top-secret hibernation program but is forgotten, awakening to a future so incredibly moronic he's easily the most intelligent person alive.\n\nSee more info [on IMDB](https://imdb.com/title/tt0387808)",
+            image: {
+              url: 'https://m.media-amazon.com/images/M/MV5BMWQ4MzI2ZDQtYjk3MS00ODdjLTkwN2QtOTBjYzIwM2RmNzgyXkEyXkFqcGdeQXVyMTQxNzMzNDI@._V1_.jpg',
+            },
+            createdAt: '2022-01-17T09:32:08.570Z',
+            updatedAt: '2022-01-18T08:48:02.876Z',
+            publishedAt: '2022-01-17T09:32:12.868Z',
+          },
+        },
+      },
+    },
+  },
+  {
+    id: 60,
+    attributes: {
+      start_time: '2022-02-07T21:00:00.000Z',
+      room: 'Stora salongen',
+      createdAt: '2022-01-23T10:32:32.752Z',
+      updatedAt: '2022-01-23T10:32:32.752Z',
+      movie: {
+        data: {
+          id: 3,
+          attributes: {
+            title: 'The Godfather: Part II',
+            imdbId: 'tt0071562',
+            intro:
+              'The early life and career of **Vito Corleone** in 1920s New York City is portrayed, while his son, **Michael**, expands and tightens his grip on the family crime syndicate.\n\nSee more info [on IMDB](https://imdb.com/title/tt0071562)',
+            image: {
+              url: 'https://m.media-amazon.com/images/M/MV5BMWMwMGQzZTItY2JlNC00OWZiLWIyMDctNDk2ZDQ2YjRjMWQ0XkEyXkFqcGdeQXVyNzkwMjQ5NzM@._V1_.jpg',
+            },
+            createdAt: '2022-01-17T05:00:31.562Z',
+            updatedAt: '2022-01-18T08:46:47.388Z',
+            publishedAt: '2022-01-17T05:00:33.453Z',
+          },
+        },
+      },
+    },
+  },
+  {
+    id: 61,
+    attributes: {
+      start_time: '2022-02-08T12:00:00.000Z',
+      room: 'Stora salongen',
+      createdAt: '2022-01-23T10:32:33.367Z',
+      updatedAt: '2022-01-23T10:32:33.367Z',
+      movie: {
+        data: {
+          id: 4,
+          attributes: {
+            title: 'The Dark Knight',
+            imdbId: 'tt0468569',
+            intro:
+              'When the menace known as the Joker wreaks havoc and chaos on the people of Gotham, **Batman** must accept one of the greatest psychological and physical tests of his ability to fight injustice.\n\nSee more info [on IMDB](https://imdb.com/title/tt0468569)',
+            image: {
+              url: 'https://m.media-amazon.com/images/M/MV5BMTMxNTMwODM0NF5BMl5BanBnXkFtZTcwODAyMTk2Mw@@._V1_.jpg',
+            },
+            createdAt: '2022-01-17T05:00:58.423Z',
+            updatedAt: '2022-01-18T08:47:52.866Z',
+            publishedAt: '2022-01-17T05:01:00.594Z',
+          },
+        },
+      },
+    },
+  },
+  {
+    id: 62,
+    attributes: {
+      start_time: '2022-02-08T17:00:00.000Z',
+      room: 'Stora salongen',
+      createdAt: '2022-01-23T10:32:33.919Z',
+      updatedAt: '2022-01-23T10:32:33.919Z',
+      movie: {
+        data: {
+          id: 5,
+          attributes: {
+            title: '12 Angry Men',
+            imdbId: 'tt0050083',
+            intro:
+              'The jury in a New York City murder trial is frustrated by a single member whose skeptical caution forces them to more carefully consider the evidence before jumping to a hasty verdict.\n\nSee more info [on IMDB](https://imdb.com/title/tt0050083)',
+            image: {
+              url: 'https://m.media-amazon.com/images/M/MV5BMWU4N2FjNzYtNTVkNC00NzQ0LTg0MjAtYTJlMjFhNGUxZDFmXkEyXkFqcGdeQXVyNjc1NTYyMjg@._V1_.jpg',
+            },
+            createdAt: '2022-01-17T05:01:21.807Z',
+            updatedAt: '2022-01-18T08:48:15.429Z',
+            publishedAt: '2022-01-17T05:01:24.036Z',
+          },
+        },
+      },
+    },
+  },
+  {
+    id: 63,
+    attributes: {
+      start_time: '2022-02-08T19:00:00.000Z',
+      room: 'Stora salongen',
+      createdAt: '2022-01-23T10:32:34.469Z',
+      updatedAt: '2022-01-23T10:32:34.469Z',
+      movie: {
+        data: {
+          id: 10,
+          attributes: {
+            title: 'Threat Level Midnight: The Movie',
+            imdbId: 'tt11620828',
+            intro:
+              'After secret agent **Michael Scarn** (played by Steve Carell) is forced into retirement due to the death of his wife **Catherine Zeta-Scarn**, the President of the United States of America (played by Craig Robinson) requests that he prevents **Goldenface** (played by John Krasinski) from blowing up the NHL All-Star Game and killing several hostages.\n\nSee more info [on IMDB](https://imdb.com/title/tt11620828)',
+            image: {
+              url: 'https://m.media-amazon.com/images/M/MV5BZjMzNzE4ZGItMDI5Zi00ZjE3LThkODctYTlhZWY1ZTdmMGNjXkEyXkFqcGdeQXVyOTExNzM4NDM@._V1_.jpg',
+            },
+            createdAt: '2022-01-17T10:51:45.145Z',
+            updatedAt: '2022-01-18T08:47:13.309Z',
+            publishedAt: '2022-01-17T10:51:53.355Z',
+          },
+        },
+      },
+    },
+  },
+  {
+    id: 64,
+    attributes: {
+      start_time: '2022-02-08T21:00:00.000Z',
+      room: 'Stora salongen',
+      createdAt: '2022-01-23T10:32:35.006Z',
+      updatedAt: '2022-01-23T10:32:35.006Z',
+      movie: {
+        data: {
+          id: 10,
+          attributes: {
+            title: 'Threat Level Midnight: The Movie',
+            imdbId: 'tt11620828',
+            intro:
+              'After secret agent **Michael Scarn** (played by Steve Carell) is forced into retirement due to the death of his wife **Catherine Zeta-Scarn**, the President of the United States of America (played by Craig Robinson) requests that he prevents **Goldenface** (played by John Krasinski) from blowing up the NHL All-Star Game and killing several hostages.\n\nSee more info [on IMDB](https://imdb.com/title/tt11620828)',
+            image: {
+              url: 'https://m.media-amazon.com/images/M/MV5BZjMzNzE4ZGItMDI5Zi00ZjE3LThkODctYTlhZWY1ZTdmMGNjXkEyXkFqcGdeQXVyOTExNzM4NDM@._V1_.jpg',
+            },
+            createdAt: '2022-01-17T10:51:45.145Z',
+            updatedAt: '2022-01-18T08:47:13.309Z',
+            publishedAt: '2022-01-17T10:51:53.355Z',
+          },
+        },
+      },
+    },
+  },
+  {
+    id: 65,
+    attributes: {
+      start_time: '2022-02-09T12:00:00.000Z',
+      room: 'Stora salongen',
+      createdAt: '2022-01-23T10:32:35.544Z',
+      updatedAt: '2022-01-23T10:32:35.544Z',
+      movie: {
+        data: {
+          id: 10,
+          attributes: {
+            title: 'Threat Level Midnight: The Movie',
+            imdbId: 'tt11620828',
+            intro:
+              'After secret agent **Michael Scarn** (played by Steve Carell) is forced into retirement due to the death of his wife **Catherine Zeta-Scarn**, the President of the United States of America (played by Craig Robinson) requests that he prevents **Goldenface** (played by John Krasinski) from blowing up the NHL All-Star Game and killing several hostages.\n\nSee more info [on IMDB](https://imdb.com/title/tt11620828)',
+            image: {
+              url: 'https://m.media-amazon.com/images/M/MV5BZjMzNzE4ZGItMDI5Zi00ZjE3LThkODctYTlhZWY1ZTdmMGNjXkEyXkFqcGdeQXVyOTExNzM4NDM@._V1_.jpg',
+            },
+            createdAt: '2022-01-17T10:51:45.145Z',
+            updatedAt: '2022-01-18T08:47:13.309Z',
+            publishedAt: '2022-01-17T10:51:53.355Z',
+          },
+        },
+      },
+    },
+  },
+  {
+    id: 66,
+    attributes: {
+      start_time: '2022-02-09T17:00:00.000Z',
+      room: 'Stora salongen',
+      createdAt: '2022-01-23T10:32:36.075Z',
+      updatedAt: '2022-01-23T10:32:36.075Z',
+      movie: {
+        data: {
+          id: 4,
+          attributes: {
+            title: 'The Dark Knight',
+            imdbId: 'tt0468569',
+            intro:
+              'When the menace known as the Joker wreaks havoc and chaos on the people of Gotham, **Batman** must accept one of the greatest psychological and physical tests of his ability to fight injustice.\n\nSee more info [on IMDB](https://imdb.com/title/tt0468569)',
+            image: {
+              url: 'https://m.media-amazon.com/images/M/MV5BMTMxNTMwODM0NF5BMl5BanBnXkFtZTcwODAyMTk2Mw@@._V1_.jpg',
+            },
+            createdAt: '2022-01-17T05:00:58.423Z',
+            updatedAt: '2022-01-18T08:47:52.866Z',
+            publishedAt: '2022-01-17T05:01:00.594Z',
+          },
+        },
+      },
+    },
+  },
+  {
+    id: 67,
+    attributes: {
+      start_time: '2022-02-09T19:00:00.000Z',
+      room: 'Stora salongen',
+      createdAt: '2022-01-23T10:32:36.776Z',
+      updatedAt: '2022-01-23T10:32:36.776Z',
+      movie: {
+        data: {
+          id: 5,
+          attributes: {
+            title: '12 Angry Men',
+            imdbId: 'tt0050083',
+            intro:
+              'The jury in a New York City murder trial is frustrated by a single member whose skeptical caution forces them to more carefully consider the evidence before jumping to a hasty verdict.\n\nSee more info [on IMDB](https://imdb.com/title/tt0050083)',
+            image: {
+              url: 'https://m.media-amazon.com/images/M/MV5BMWU4N2FjNzYtNTVkNC00NzQ0LTg0MjAtYTJlMjFhNGUxZDFmXkEyXkFqcGdeQXVyNjc1NTYyMjg@._V1_.jpg',
+            },
+            createdAt: '2022-01-17T05:01:21.807Z',
+            updatedAt: '2022-01-18T08:48:15.429Z',
+            publishedAt: '2022-01-17T05:01:24.036Z',
+          },
+        },
+      },
+    },
+  },
+  {
+    id: 68,
+    attributes: {
+      start_time: '2022-02-09T21:00:00.000Z',
+      room: 'Stora salongen',
+      createdAt: '2022-01-23T10:32:37.605Z',
+      updatedAt: '2022-01-23T10:32:37.605Z',
+      movie: {
+        data: {
+          id: 1,
+          attributes: {
+            title: 'The Shawshank Redemption',
+            imdbId: 'tt0111161',
+            intro:
+              'Two imprisoned men bond over a number of years, finding solace and eventual redemption through acts of common decency.\n\nSee more info [on IMDB](https://imdb.com/title/tt0111161)',
+            image: {
+              url: 'https://m.media-amazon.com/images/M/MV5BMDFkYTc0MGEtZmNhMC00ZDIzLWFmNTEtODM1ZmRlYWMwMWFmXkEyXkFqcGdeQXVyMTMxODk2OTU@._V1_.jpg',
+            },
+            createdAt: '2022-01-17T04:59:14.315Z',
+            updatedAt: '2022-01-18T08:47:01.417Z',
+            publishedAt: '2022-01-17T04:59:16.846Z',
+          },
+        },
+      },
+    },
+  },
+  {
+    id: 69,
+    attributes: {
+      start_time: '2022-02-10T12:00:00.000Z',
+      room: 'Stora salongen',
+      createdAt: '2022-01-23T10:32:38.433Z',
+      updatedAt: '2022-01-23T10:32:38.433Z',
+      movie: {
+        data: {
+          id: 5,
+          attributes: {
+            title: '12 Angry Men',
+            imdbId: 'tt0050083',
+            intro:
+              'The jury in a New York City murder trial is frustrated by a single member whose skeptical caution forces them to more carefully consider the evidence before jumping to a hasty verdict.\n\nSee more info [on IMDB](https://imdb.com/title/tt0050083)',
+            image: {
+              url: 'https://m.media-amazon.com/images/M/MV5BMWU4N2FjNzYtNTVkNC00NzQ0LTg0MjAtYTJlMjFhNGUxZDFmXkEyXkFqcGdeQXVyNjc1NTYyMjg@._V1_.jpg',
+            },
+            createdAt: '2022-01-17T05:01:21.807Z',
+            updatedAt: '2022-01-18T08:48:15.429Z',
+            publishedAt: '2022-01-17T05:01:24.036Z',
+          },
+        },
+      },
+    },
+  },
+  {
+    id: 70,
+    attributes: {
+      start_time: '2022-02-10T17:00:00.000Z',
+      room: 'Stora salongen',
+      createdAt: '2022-01-23T10:32:39.247Z',
+      updatedAt: '2022-01-23T10:32:39.247Z',
+      movie: {
+        data: {
+          id: 2,
+          attributes: {
+            title: 'The Godfather',
+            imdbId: 'tt0068646',
+            intro:
+              'The Godfather follows **Vito Corleone**, Don of the Corleone family, as he passes the mantel to his unwilling son, **Michael**.\n\nSee more info [on IMDB](https://imdb.com/title/tt0068646)',
+            image: {
+              url: 'https://m.media-amazon.com/images/M/MV5BM2MyNjYxNmUtYTAwNi00MTYxLWJmNWYtYzZlODY3ZTk3OTFlXkEyXkFqcGdeQXVyNzkwMjQ5NzM@._V1_.jpg',
+            },
+            createdAt: '2022-01-17T04:59:42.763Z',
+            updatedAt: '2022-01-18T08:47:25.840Z',
+            publishedAt: '2022-01-17T04:59:44.929Z',
+          },
+        },
+      },
+    },
+  },
+  {
+    id: 71,
+    attributes: {
+      start_time: '2022-02-10T19:00:00.000Z',
+      room: 'Stora salongen',
+      createdAt: '2022-01-23T10:32:39.883Z',
+      updatedAt: '2022-01-23T10:32:39.883Z',
+      movie: {
+        data: {
+          id: 5,
+          attributes: {
+            title: '12 Angry Men',
+            imdbId: 'tt0050083',
+            intro:
+              'The jury in a New York City murder trial is frustrated by a single member whose skeptical caution forces them to more carefully consider the evidence before jumping to a hasty verdict.\n\nSee more info [on IMDB](https://imdb.com/title/tt0050083)',
+            image: {
+              url: 'https://m.media-amazon.com/images/M/MV5BMWU4N2FjNzYtNTVkNC00NzQ0LTg0MjAtYTJlMjFhNGUxZDFmXkEyXkFqcGdeQXVyNjc1NTYyMjg@._V1_.jpg',
+            },
+            createdAt: '2022-01-17T05:01:21.807Z',
+            updatedAt: '2022-01-18T08:48:15.429Z',
+            publishedAt: '2022-01-17T05:01:24.036Z',
+          },
+        },
+      },
+    },
+  },
+  {
+    id: 72,
+    attributes: {
+      start_time: '2022-02-10T21:00:00.000Z',
+      room: 'Stora salongen',
+      createdAt: '2022-01-23T10:32:40.408Z',
+      updatedAt: '2022-01-23T10:32:40.408Z',
+      movie: {
+        data: {
+          id: 10,
+          attributes: {
+            title: 'Threat Level Midnight: The Movie',
+            imdbId: 'tt11620828',
+            intro:
+              'After secret agent **Michael Scarn** (played by Steve Carell) is forced into retirement due to the death of his wife **Catherine Zeta-Scarn**, the President of the United States of America (played by Craig Robinson) requests that he prevents **Goldenface** (played by John Krasinski) from blowing up the NHL All-Star Game and killing several hostages.\n\nSee more info [on IMDB](https://imdb.com/title/tt11620828)',
+            image: {
+              url: 'https://m.media-amazon.com/images/M/MV5BZjMzNzE4ZGItMDI5Zi00ZjE3LThkODctYTlhZWY1ZTdmMGNjXkEyXkFqcGdeQXVyOTExNzM4NDM@._V1_.jpg',
+            },
+            createdAt: '2022-01-17T10:51:45.145Z',
+            updatedAt: '2022-01-18T08:47:13.309Z',
+            publishedAt: '2022-01-17T10:51:53.355Z',
+          },
+        },
+      },
+    },
+  },
+  {
+    id: 73,
+    attributes: {
+      start_time: '2022-02-11T12:00:00.000Z',
+      room: 'Stora salongen',
+      createdAt: '2022-01-23T10:32:40.940Z',
+      updatedAt: '2022-01-23T10:32:40.940Z',
+      movie: {
+        data: {
+          id: 5,
+          attributes: {
+            title: '12 Angry Men',
+            imdbId: 'tt0050083',
+            intro:
+              'The jury in a New York City murder trial is frustrated by a single member whose skeptical caution forces them to more carefully consider the evidence before jumping to a hasty verdict.\n\nSee more info [on IMDB](https://imdb.com/title/tt0050083)',
+            image: {
+              url: 'https://m.media-amazon.com/images/M/MV5BMWU4N2FjNzYtNTVkNC00NzQ0LTg0MjAtYTJlMjFhNGUxZDFmXkEyXkFqcGdeQXVyNjc1NTYyMjg@._V1_.jpg',
+            },
+            createdAt: '2022-01-17T05:01:21.807Z',
+            updatedAt: '2022-01-18T08:48:15.429Z',
+            publishedAt: '2022-01-17T05:01:24.036Z',
+          },
+        },
+      },
+    },
+  },
+  {
+    id: 74,
+    attributes: {
+      start_time: '2022-02-11T17:00:00.000Z',
+      room: 'Stora salongen',
+      createdAt: '2022-01-23T10:32:41.527Z',
+      updatedAt: '2022-01-23T10:32:41.527Z',
+      movie: {
+        data: {
+          id: 2,
+          attributes: {
+            title: 'The Godfather',
+            imdbId: 'tt0068646',
+            intro:
+              'The Godfather follows **Vito Corleone**, Don of the Corleone family, as he passes the mantel to his unwilling son, **Michael**.\n\nSee more info [on IMDB](https://imdb.com/title/tt0068646)',
+            image: {
+              url: 'https://m.media-amazon.com/images/M/MV5BM2MyNjYxNmUtYTAwNi00MTYxLWJmNWYtYzZlODY3ZTk3OTFlXkEyXkFqcGdeQXVyNzkwMjQ5NzM@._V1_.jpg',
+            },
+            createdAt: '2022-01-17T04:59:42.763Z',
+            updatedAt: '2022-01-18T08:47:25.840Z',
+            publishedAt: '2022-01-17T04:59:44.929Z',
+          },
+        },
+      },
+    },
+  },
+  {
+    id: 75,
+    attributes: {
+      start_time: '2022-02-11T19:00:00.000Z',
+      room: 'Stora salongen',
+      createdAt: '2022-01-23T10:32:42.401Z',
+      updatedAt: '2022-01-23T10:32:42.401Z',
+      movie: {
+        data: {
+          id: 3,
+          attributes: {
+            title: 'The Godfather: Part II',
+            imdbId: 'tt0071562',
+            intro:
+              'The early life and career of **Vito Corleone** in 1920s New York City is portrayed, while his son, **Michael**, expands and tightens his grip on the family crime syndicate.\n\nSee more info [on IMDB](https://imdb.com/title/tt0071562)',
+            image: {
+              url: 'https://m.media-amazon.com/images/M/MV5BMWMwMGQzZTItY2JlNC00OWZiLWIyMDctNDk2ZDQ2YjRjMWQ0XkEyXkFqcGdeQXVyNzkwMjQ5NzM@._V1_.jpg',
+            },
+            createdAt: '2022-01-17T05:00:31.562Z',
+            updatedAt: '2022-01-18T08:46:47.388Z',
+            publishedAt: '2022-01-17T05:00:33.453Z',
+          },
+        },
+      },
+    },
+  },
+  {
+    id: 76,
+    attributes: {
+      start_time: '2022-02-11T21:00:00.000Z',
+      room: 'Stora salongen',
+      createdAt: '2022-01-23T10:32:42.953Z',
+      updatedAt: '2022-01-23T10:32:42.953Z',
+      movie: {
+        data: {
+          id: 5,
+          attributes: {
+            title: '12 Angry Men',
+            imdbId: 'tt0050083',
+            intro:
+              'The jury in a New York City murder trial is frustrated by a single member whose skeptical caution forces them to more carefully consider the evidence before jumping to a hasty verdict.\n\nSee more info [on IMDB](https://imdb.com/title/tt0050083)',
+            image: {
+              url: 'https://m.media-amazon.com/images/M/MV5BMWU4N2FjNzYtNTVkNC00NzQ0LTg0MjAtYTJlMjFhNGUxZDFmXkEyXkFqcGdeQXVyNjc1NTYyMjg@._V1_.jpg',
+            },
+            createdAt: '2022-01-17T05:01:21.807Z',
+            updatedAt: '2022-01-18T08:48:15.429Z',
+            publishedAt: '2022-01-17T05:01:24.036Z',
+          },
+        },
+      },
+    },
+  },
+  {
+    id: 77,
+    attributes: {
+      start_time: '2022-02-12T12:00:00.000Z',
+      room: 'Stora salongen',
+      createdAt: '2022-01-23T10:32:43.668Z',
+      updatedAt: '2022-01-23T10:32:43.668Z',
+      movie: {
+        data: {
+          id: 3,
+          attributes: {
+            title: 'The Godfather: Part II',
+            imdbId: 'tt0071562',
+            intro:
+              'The early life and career of **Vito Corleone** in 1920s New York City is portrayed, while his son, **Michael**, expands and tightens his grip on the family crime syndicate.\n\nSee more info [on IMDB](https://imdb.com/title/tt0071562)',
+            image: {
+              url: 'https://m.media-amazon.com/images/M/MV5BMWMwMGQzZTItY2JlNC00OWZiLWIyMDctNDk2ZDQ2YjRjMWQ0XkEyXkFqcGdeQXVyNzkwMjQ5NzM@._V1_.jpg',
+            },
+            createdAt: '2022-01-17T05:00:31.562Z',
+            updatedAt: '2022-01-18T08:46:47.388Z',
+            publishedAt: '2022-01-17T05:00:33.453Z',
+          },
+        },
+      },
+    },
+  },
+  {
+    id: 78,
+    attributes: {
+      start_time: '2022-02-12T17:00:00.000Z',
+      room: 'Stora salongen',
+      createdAt: '2022-01-23T10:32:44.202Z',
+      updatedAt: '2022-01-23T10:32:44.202Z',
+      movie: {
+        data: {
+          id: 5,
+          attributes: {
+            title: '12 Angry Men',
+            imdbId: 'tt0050083',
+            intro:
+              'The jury in a New York City murder trial is frustrated by a single member whose skeptical caution forces them to more carefully consider the evidence before jumping to a hasty verdict.\n\nSee more info [on IMDB](https://imdb.com/title/tt0050083)',
+            image: {
+              url: 'https://m.media-amazon.com/images/M/MV5BMWU4N2FjNzYtNTVkNC00NzQ0LTg0MjAtYTJlMjFhNGUxZDFmXkEyXkFqcGdeQXVyNjc1NTYyMjg@._V1_.jpg',
+            },
+            createdAt: '2022-01-17T05:01:21.807Z',
+            updatedAt: '2022-01-18T08:48:15.429Z',
+            publishedAt: '2022-01-17T05:01:24.036Z',
+          },
+        },
+      },
+    },
+  },
+  {
+    id: 79,
+    attributes: {
+      start_time: '2022-02-12T19:00:00.000Z',
+      room: 'Stora salongen',
+      createdAt: '2022-01-23T10:32:44.767Z',
+      updatedAt: '2022-01-23T10:32:44.767Z',
+      movie: {
+        data: {
+          id: 10,
+          attributes: {
+            title: 'Threat Level Midnight: The Movie',
+            imdbId: 'tt11620828',
+            intro:
+              'After secret agent **Michael Scarn** (played by Steve Carell) is forced into retirement due to the death of his wife **Catherine Zeta-Scarn**, the President of the United States of America (played by Craig Robinson) requests that he prevents **Goldenface** (played by John Krasinski) from blowing up the NHL All-Star Game and killing several hostages.\n\nSee more info [on IMDB](https://imdb.com/title/tt11620828)',
+            image: {
+              url: 'https://m.media-amazon.com/images/M/MV5BZjMzNzE4ZGItMDI5Zi00ZjE3LThkODctYTlhZWY1ZTdmMGNjXkEyXkFqcGdeQXVyOTExNzM4NDM@._V1_.jpg',
+            },
+            createdAt: '2022-01-17T10:51:45.145Z',
+            updatedAt: '2022-01-18T08:47:13.309Z',
+            publishedAt: '2022-01-17T10:51:53.355Z',
+          },
+        },
+      },
+    },
+  },
+  {
+    id: 80,
+    attributes: {
+      start_time: '2022-02-12T21:00:00.000Z',
+      room: 'Stora salongen',
+      createdAt: '2022-01-23T10:32:45.313Z',
+      updatedAt: '2022-01-23T10:32:45.313Z',
+      movie: {
+        data: {
+          id: 2,
+          attributes: {
+            title: 'The Godfather',
+            imdbId: 'tt0068646',
+            intro:
+              'The Godfather follows **Vito Corleone**, Don of the Corleone family, as he passes the mantel to his unwilling son, **Michael**.\n\nSee more info [on IMDB](https://imdb.com/title/tt0068646)',
+            image: {
+              url: 'https://m.media-amazon.com/images/M/MV5BM2MyNjYxNmUtYTAwNi00MTYxLWJmNWYtYzZlODY3ZTk3OTFlXkEyXkFqcGdeQXVyNzkwMjQ5NzM@._V1_.jpg',
+            },
+            createdAt: '2022-01-17T04:59:42.763Z',
+            updatedAt: '2022-01-18T08:47:25.840Z',
+            publishedAt: '2022-01-17T04:59:44.929Z',
+          },
+        },
+      },
+    },
+  },
+];

--- a/tests/screenings.spec.js
+++ b/tests/screenings.spec.js
@@ -35,7 +35,7 @@ test('If old screenings are removed from array', async () => {
   const filteredScreenings = filterOldScreenings(screeningsArray, date);
 
   filteredScreenings.forEach((screening) => {
-    expect(Date.parse(screening.start_time) > Date.parse(date));
+    expect(Date.parse(screening.start_time) > Date.parse(date)).toBeTruthy();
   });
 });
 
@@ -51,7 +51,9 @@ test('If only screenings five days ahead is in the array', async () => {
   );
 
   futureScreenings.forEach((screening) => {
-    expect(Date.parse(screening.start_time) < Date.parse(futureDate));
+    expect(
+      Date.parse(screening.start_time) < Date.parse(futureDate)
+    ).toBeTruthy();
   });
 });
 

--- a/tests/screenings.spec.js
+++ b/tests/screenings.spec.js
@@ -1,0 +1,2019 @@
+import {trimData} from '../src/screenings.js'
+
+test('If array gets trimmed down to id, title, start_time, movieId and image', async () => {
+  const screeningsArray = data;
+  const trimmedDataObj = await trimData(screeningsArray);
+  console.log(trimmedDataObj.splice(0, 10));
+
+  expect(trimmedDataObj[0].id).toBeTruthy();
+  expect(trimmedDataObj[0].title).toBeTruthy();
+  expect(trimmedDataObj[0].start_time).toBeTruthy();
+  expect(trimmedDataObj[0].movieId).toBeTruthy();
+  expect(trimmedDataObj[0].image).toBeTruthy();
+})
+
+
+
+// MOCK data
+const data = [
+      {
+          "id": 1,
+          "attributes": {
+              "start_time": "2022-01-24T12:00:00.000Z",
+              "room": "Stora salongen",
+              "createdAt": "2022-01-23T10:31:58.536Z",
+              "updatedAt": "2022-01-23T10:31:58.536Z",
+              "movie": {
+                  "data": {
+                      "id": 10,
+                      "attributes": {
+                          "title": "Threat Level Midnight: The Movie",
+                          "imdbId": "tt11620828",
+                          "intro": "After secret agent **Michael Scarn** (played by Steve Carell) is forced into retirement due to the death of his wife **Catherine Zeta-Scarn**, the President of the United States of America (played by Craig Robinson) requests that he prevents **Goldenface** (played by John Krasinski) from blowing up the NHL All-Star Game and killing several hostages.\n\nSee more info [on IMDB](https://imdb.com/title/tt11620828)",
+                          "image": {
+                              "url": "https://m.media-amazon.com/images/M/MV5BZjMzNzE4ZGItMDI5Zi00ZjE3LThkODctYTlhZWY1ZTdmMGNjXkEyXkFqcGdeQXVyOTExNzM4NDM@._V1_.jpg"
+                          },
+                          "createdAt": "2022-01-17T10:51:45.145Z",
+                          "updatedAt": "2022-01-18T08:47:13.309Z",
+                          "publishedAt": "2022-01-17T10:51:53.355Z"
+                      }
+                  }
+              }
+          }
+      },
+      {
+          "id": 2,
+          "attributes": {
+              "start_time": "2022-01-24T17:00:00.000Z",
+              "room": "Stora salongen",
+              "createdAt": "2022-01-23T10:31:59.065Z",
+              "updatedAt": "2022-01-23T10:31:59.065Z",
+              "movie": {
+                  "data": {
+                      "id": 8,
+                      "attributes": {
+                          "title": "Idiocracy",
+                          "imdbId": "tt0387808",
+                          "intro": "Private **Joe Bauers**, a decisively average American, is selected as a guinea pig for a top-secret hibernation program but is forgotten, awakening to a future so incredibly moronic he's easily the most intelligent person alive.\n\nSee more info [on IMDB](https://imdb.com/title/tt0387808)",
+                          "image": {
+                              "url": "https://m.media-amazon.com/images/M/MV5BMWQ4MzI2ZDQtYjk3MS00ODdjLTkwN2QtOTBjYzIwM2RmNzgyXkEyXkFqcGdeQXVyMTQxNzMzNDI@._V1_.jpg"
+                          },
+                          "createdAt": "2022-01-17T09:32:08.570Z",
+                          "updatedAt": "2022-01-18T08:48:02.876Z",
+                          "publishedAt": "2022-01-17T09:32:12.868Z"
+                      }
+                  }
+              }
+          }
+      },
+      {
+          "id": 3,
+          "attributes": {
+              "start_time": "2022-01-24T19:00:00.000Z",
+              "room": "Stora salongen",
+              "createdAt": "2022-01-23T10:31:59.612Z",
+              "updatedAt": "2022-01-23T10:31:59.612Z",
+              "movie": {
+                  "data": {
+                      "id": 5,
+                      "attributes": {
+                          "title": "12 Angry Men",
+                          "imdbId": "tt0050083",
+                          "intro": "The jury in a New York City murder trial is frustrated by a single member whose skeptical caution forces them to more carefully consider the evidence before jumping to a hasty verdict.\n\nSee more info [on IMDB](https://imdb.com/title/tt0050083)",
+                          "image": {
+                              "url": "https://m.media-amazon.com/images/M/MV5BMWU4N2FjNzYtNTVkNC00NzQ0LTg0MjAtYTJlMjFhNGUxZDFmXkEyXkFqcGdeQXVyNjc1NTYyMjg@._V1_.jpg"
+                          },
+                          "createdAt": "2022-01-17T05:01:21.807Z",
+                          "updatedAt": "2022-01-18T08:48:15.429Z",
+                          "publishedAt": "2022-01-17T05:01:24.036Z"
+                      }
+                  }
+              }
+          }
+      },
+      {
+          "id": 4,
+          "attributes": {
+              "start_time": "2022-01-24T21:00:00.000Z",
+              "room": "Stora salongen",
+              "createdAt": "2022-01-23T10:32:00.277Z",
+              "updatedAt": "2022-01-23T10:32:00.277Z",
+              "movie": {
+                  "data": {
+                      "id": 5,
+                      "attributes": {
+                          "title": "12 Angry Men",
+                          "imdbId": "tt0050083",
+                          "intro": "The jury in a New York City murder trial is frustrated by a single member whose skeptical caution forces them to more carefully consider the evidence before jumping to a hasty verdict.\n\nSee more info [on IMDB](https://imdb.com/title/tt0050083)",
+                          "image": {
+                              "url": "https://m.media-amazon.com/images/M/MV5BMWU4N2FjNzYtNTVkNC00NzQ0LTg0MjAtYTJlMjFhNGUxZDFmXkEyXkFqcGdeQXVyNjc1NTYyMjg@._V1_.jpg"
+                          },
+                          "createdAt": "2022-01-17T05:01:21.807Z",
+                          "updatedAt": "2022-01-18T08:48:15.429Z",
+                          "publishedAt": "2022-01-17T05:01:24.036Z"
+                      }
+                  }
+              }
+          }
+      },
+      {
+          "id": 5,
+          "attributes": {
+              "start_time": "2022-01-25T12:00:00.000Z",
+              "room": "Stora salongen",
+              "createdAt": "2022-01-23T10:32:00.822Z",
+              "updatedAt": "2022-01-23T10:32:00.822Z",
+              "movie": {
+                  "data": {
+                      "id": 3,
+                      "attributes": {
+                          "title": "The Godfather: Part II",
+                          "imdbId": "tt0071562",
+                          "intro": "The early life and career of **Vito Corleone** in 1920s New York City is portrayed, while his son, **Michael**, expands and tightens his grip on the family crime syndicate.\n\nSee more info [on IMDB](https://imdb.com/title/tt0071562)",
+                          "image": {
+                              "url": "https://m.media-amazon.com/images/M/MV5BMWMwMGQzZTItY2JlNC00OWZiLWIyMDctNDk2ZDQ2YjRjMWQ0XkEyXkFqcGdeQXVyNzkwMjQ5NzM@._V1_.jpg"
+                          },
+                          "createdAt": "2022-01-17T05:00:31.562Z",
+                          "updatedAt": "2022-01-18T08:46:47.388Z",
+                          "publishedAt": "2022-01-17T05:00:33.453Z"
+                      }
+                  }
+              }
+          }
+      },
+      {
+          "id": 6,
+          "attributes": {
+              "start_time": "2022-01-25T17:00:00.000Z",
+              "room": "Stora salongen",
+              "createdAt": "2022-01-23T10:32:01.366Z",
+              "updatedAt": "2022-01-23T10:32:01.366Z",
+              "movie": {
+                  "data": {
+                      "id": 3,
+                      "attributes": {
+                          "title": "The Godfather: Part II",
+                          "imdbId": "tt0071562",
+                          "intro": "The early life and career of **Vito Corleone** in 1920s New York City is portrayed, while his son, **Michael**, expands and tightens his grip on the family crime syndicate.\n\nSee more info [on IMDB](https://imdb.com/title/tt0071562)",
+                          "image": {
+                              "url": "https://m.media-amazon.com/images/M/MV5BMWMwMGQzZTItY2JlNC00OWZiLWIyMDctNDk2ZDQ2YjRjMWQ0XkEyXkFqcGdeQXVyNzkwMjQ5NzM@._V1_.jpg"
+                          },
+                          "createdAt": "2022-01-17T05:00:31.562Z",
+                          "updatedAt": "2022-01-18T08:46:47.388Z",
+                          "publishedAt": "2022-01-17T05:00:33.453Z"
+                      }
+                  }
+              }
+          }
+      },
+      {
+          "id": 7,
+          "attributes": {
+              "start_time": "2022-01-25T19:00:00.000Z",
+              "room": "Stora salongen",
+              "createdAt": "2022-01-23T10:32:01.931Z",
+              "updatedAt": "2022-01-23T10:32:01.931Z",
+              "movie": {
+                  "data": {
+                      "id": 10,
+                      "attributes": {
+                          "title": "Threat Level Midnight: The Movie",
+                          "imdbId": "tt11620828",
+                          "intro": "After secret agent **Michael Scarn** (played by Steve Carell) is forced into retirement due to the death of his wife **Catherine Zeta-Scarn**, the President of the United States of America (played by Craig Robinson) requests that he prevents **Goldenface** (played by John Krasinski) from blowing up the NHL All-Star Game and killing several hostages.\n\nSee more info [on IMDB](https://imdb.com/title/tt11620828)",
+                          "image": {
+                              "url": "https://m.media-amazon.com/images/M/MV5BZjMzNzE4ZGItMDI5Zi00ZjE3LThkODctYTlhZWY1ZTdmMGNjXkEyXkFqcGdeQXVyOTExNzM4NDM@._V1_.jpg"
+                          },
+                          "createdAt": "2022-01-17T10:51:45.145Z",
+                          "updatedAt": "2022-01-18T08:47:13.309Z",
+                          "publishedAt": "2022-01-17T10:51:53.355Z"
+                      }
+                  }
+              }
+          }
+      },
+      {
+          "id": 8,
+          "attributes": {
+              "start_time": "2022-01-25T21:00:00.000Z",
+              "room": "Stora salongen",
+              "createdAt": "2022-01-23T10:32:02.611Z",
+              "updatedAt": "2022-01-23T10:32:02.611Z",
+              "movie": {
+                  "data": {
+                      "id": 1,
+                      "attributes": {
+                          "title": "The Shawshank Redemption",
+                          "imdbId": "tt0111161",
+                          "intro": "Two imprisoned men bond over a number of years, finding solace and eventual redemption through acts of common decency.\n\nSee more info [on IMDB](https://imdb.com/title/tt0111161)",
+                          "image": {
+                              "url": "https://m.media-amazon.com/images/M/MV5BMDFkYTc0MGEtZmNhMC00ZDIzLWFmNTEtODM1ZmRlYWMwMWFmXkEyXkFqcGdeQXVyMTMxODk2OTU@._V1_.jpg"
+                          },
+                          "createdAt": "2022-01-17T04:59:14.315Z",
+                          "updatedAt": "2022-01-18T08:47:01.417Z",
+                          "publishedAt": "2022-01-17T04:59:16.846Z"
+                      }
+                  }
+              }
+          }
+      },
+      {
+          "id": 9,
+          "attributes": {
+              "start_time": "2022-01-26T12:00:00.000Z",
+              "room": "Stora salongen",
+              "createdAt": "2022-01-23T10:32:03.180Z",
+              "updatedAt": "2022-01-23T10:32:03.180Z",
+              "movie": {
+                  "data": {
+                      "id": 5,
+                      "attributes": {
+                          "title": "12 Angry Men",
+                          "imdbId": "tt0050083",
+                          "intro": "The jury in a New York City murder trial is frustrated by a single member whose skeptical caution forces them to more carefully consider the evidence before jumping to a hasty verdict.\n\nSee more info [on IMDB](https://imdb.com/title/tt0050083)",
+                          "image": {
+                              "url": "https://m.media-amazon.com/images/M/MV5BMWU4N2FjNzYtNTVkNC00NzQ0LTg0MjAtYTJlMjFhNGUxZDFmXkEyXkFqcGdeQXVyNjc1NTYyMjg@._V1_.jpg"
+                          },
+                          "createdAt": "2022-01-17T05:01:21.807Z",
+                          "updatedAt": "2022-01-18T08:48:15.429Z",
+                          "publishedAt": "2022-01-17T05:01:24.036Z"
+                      }
+                  }
+              }
+          }
+      },
+      {
+          "id": 10,
+          "attributes": {
+              "start_time": "2022-01-26T17:00:00.000Z",
+              "room": "Stora salongen",
+              "createdAt": "2022-01-23T10:32:03.768Z",
+              "updatedAt": "2022-01-23T10:32:03.768Z",
+              "movie": {
+                  "data": {
+                      "id": 3,
+                      "attributes": {
+                          "title": "The Godfather: Part II",
+                          "imdbId": "tt0071562",
+                          "intro": "The early life and career of **Vito Corleone** in 1920s New York City is portrayed, while his son, **Michael**, expands and tightens his grip on the family crime syndicate.\n\nSee more info [on IMDB](https://imdb.com/title/tt0071562)",
+                          "image": {
+                              "url": "https://m.media-amazon.com/images/M/MV5BMWMwMGQzZTItY2JlNC00OWZiLWIyMDctNDk2ZDQ2YjRjMWQ0XkEyXkFqcGdeQXVyNzkwMjQ5NzM@._V1_.jpg"
+                          },
+                          "createdAt": "2022-01-17T05:00:31.562Z",
+                          "updatedAt": "2022-01-18T08:46:47.388Z",
+                          "publishedAt": "2022-01-17T05:00:33.453Z"
+                      }
+                  }
+              }
+          }
+      },
+      {
+          "id": 11,
+          "attributes": {
+              "start_time": "2022-01-26T19:00:00.000Z",
+              "room": "Stora salongen",
+              "createdAt": "2022-01-23T10:32:04.326Z",
+              "updatedAt": "2022-01-23T10:32:04.326Z",
+              "movie": {
+                  "data": {
+                      "id": 10,
+                      "attributes": {
+                          "title": "Threat Level Midnight: The Movie",
+                          "imdbId": "tt11620828",
+                          "intro": "After secret agent **Michael Scarn** (played by Steve Carell) is forced into retirement due to the death of his wife **Catherine Zeta-Scarn**, the President of the United States of America (played by Craig Robinson) requests that he prevents **Goldenface** (played by John Krasinski) from blowing up the NHL All-Star Game and killing several hostages.\n\nSee more info [on IMDB](https://imdb.com/title/tt11620828)",
+                          "image": {
+                              "url": "https://m.media-amazon.com/images/M/MV5BZjMzNzE4ZGItMDI5Zi00ZjE3LThkODctYTlhZWY1ZTdmMGNjXkEyXkFqcGdeQXVyOTExNzM4NDM@._V1_.jpg"
+                          },
+                          "createdAt": "2022-01-17T10:51:45.145Z",
+                          "updatedAt": "2022-01-18T08:47:13.309Z",
+                          "publishedAt": "2022-01-17T10:51:53.355Z"
+                      }
+                  }
+              }
+          }
+      },
+      {
+          "id": 12,
+          "attributes": {
+              "start_time": "2022-01-26T21:00:00.000Z",
+              "room": "Stora salongen",
+              "createdAt": "2022-01-23T10:32:05.168Z",
+              "updatedAt": "2022-01-23T10:32:05.168Z",
+              "movie": {
+                  "data": {
+                      "id": 2,
+                      "attributes": {
+                          "title": "The Godfather",
+                          "imdbId": "tt0068646",
+                          "intro": "The Godfather follows **Vito Corleone**, Don of the Corleone family, as he passes the mantel to his unwilling son, **Michael**.\n\nSee more info [on IMDB](https://imdb.com/title/tt0068646)",
+                          "image": {
+                              "url": "https://m.media-amazon.com/images/M/MV5BM2MyNjYxNmUtYTAwNi00MTYxLWJmNWYtYzZlODY3ZTk3OTFlXkEyXkFqcGdeQXVyNzkwMjQ5NzM@._V1_.jpg"
+                          },
+                          "createdAt": "2022-01-17T04:59:42.763Z",
+                          "updatedAt": "2022-01-18T08:47:25.840Z",
+                          "publishedAt": "2022-01-17T04:59:44.929Z"
+                      }
+                  }
+              }
+          }
+      },
+      {
+          "id": 13,
+          "attributes": {
+              "start_time": "2022-01-27T12:00:00.000Z",
+              "room": "Stora salongen",
+              "createdAt": "2022-01-23T10:32:05.701Z",
+              "updatedAt": "2022-01-23T10:32:05.701Z",
+              "movie": {
+                  "data": {
+                      "id": 4,
+                      "attributes": {
+                          "title": "The Dark Knight",
+                          "imdbId": "tt0468569",
+                          "intro": "When the menace known as the Joker wreaks havoc and chaos on the people of Gotham, **Batman** must accept one of the greatest psychological and physical tests of his ability to fight injustice.\n\nSee more info [on IMDB](https://imdb.com/title/tt0468569)",
+                          "image": {
+                              "url": "https://m.media-amazon.com/images/M/MV5BMTMxNTMwODM0NF5BMl5BanBnXkFtZTcwODAyMTk2Mw@@._V1_.jpg"
+                          },
+                          "createdAt": "2022-01-17T05:00:58.423Z",
+                          "updatedAt": "2022-01-18T08:47:52.866Z",
+                          "publishedAt": "2022-01-17T05:01:00.594Z"
+                      }
+                  }
+              }
+          }
+      },
+      {
+          "id": 14,
+          "attributes": {
+              "start_time": "2022-01-27T17:00:00.000Z",
+              "room": "Stora salongen",
+              "createdAt": "2022-01-23T10:32:06.233Z",
+              "updatedAt": "2022-01-23T10:32:06.233Z",
+              "movie": {
+                  "data": {
+                      "id": 8,
+                      "attributes": {
+                          "title": "Idiocracy",
+                          "imdbId": "tt0387808",
+                          "intro": "Private **Joe Bauers**, a decisively average American, is selected as a guinea pig for a top-secret hibernation program but is forgotten, awakening to a future so incredibly moronic he's easily the most intelligent person alive.\n\nSee more info [on IMDB](https://imdb.com/title/tt0387808)",
+                          "image": {
+                              "url": "https://m.media-amazon.com/images/M/MV5BMWQ4MzI2ZDQtYjk3MS00ODdjLTkwN2QtOTBjYzIwM2RmNzgyXkEyXkFqcGdeQXVyMTQxNzMzNDI@._V1_.jpg"
+                          },
+                          "createdAt": "2022-01-17T09:32:08.570Z",
+                          "updatedAt": "2022-01-18T08:48:02.876Z",
+                          "publishedAt": "2022-01-17T09:32:12.868Z"
+                      }
+                  }
+              }
+          }
+      },
+      {
+          "id": 15,
+          "attributes": {
+              "start_time": "2022-01-27T19:00:00.000Z",
+              "room": "Stora salongen",
+              "createdAt": "2022-01-23T10:32:06.896Z",
+              "updatedAt": "2022-01-23T10:32:06.896Z",
+              "movie": {
+                  "data": {
+                      "id": 5,
+                      "attributes": {
+                          "title": "12 Angry Men",
+                          "imdbId": "tt0050083",
+                          "intro": "The jury in a New York City murder trial is frustrated by a single member whose skeptical caution forces them to more carefully consider the evidence before jumping to a hasty verdict.\n\nSee more info [on IMDB](https://imdb.com/title/tt0050083)",
+                          "image": {
+                              "url": "https://m.media-amazon.com/images/M/MV5BMWU4N2FjNzYtNTVkNC00NzQ0LTg0MjAtYTJlMjFhNGUxZDFmXkEyXkFqcGdeQXVyNjc1NTYyMjg@._V1_.jpg"
+                          },
+                          "createdAt": "2022-01-17T05:01:21.807Z",
+                          "updatedAt": "2022-01-18T08:48:15.429Z",
+                          "publishedAt": "2022-01-17T05:01:24.036Z"
+                      }
+                  }
+              }
+          }
+      },
+      {
+          "id": 16,
+          "attributes": {
+              "start_time": "2022-01-27T21:00:00.000Z",
+              "room": "Stora salongen",
+              "createdAt": "2022-01-23T10:32:07.444Z",
+              "updatedAt": "2022-01-23T10:32:07.444Z",
+              "movie": {
+                  "data": {
+                      "id": 5,
+                      "attributes": {
+                          "title": "12 Angry Men",
+                          "imdbId": "tt0050083",
+                          "intro": "The jury in a New York City murder trial is frustrated by a single member whose skeptical caution forces them to more carefully consider the evidence before jumping to a hasty verdict.\n\nSee more info [on IMDB](https://imdb.com/title/tt0050083)",
+                          "image": {
+                              "url": "https://m.media-amazon.com/images/M/MV5BMWU4N2FjNzYtNTVkNC00NzQ0LTg0MjAtYTJlMjFhNGUxZDFmXkEyXkFqcGdeQXVyNjc1NTYyMjg@._V1_.jpg"
+                          },
+                          "createdAt": "2022-01-17T05:01:21.807Z",
+                          "updatedAt": "2022-01-18T08:48:15.429Z",
+                          "publishedAt": "2022-01-17T05:01:24.036Z"
+                      }
+                  }
+              }
+          }
+      },
+      {
+          "id": 17,
+          "attributes": {
+              "start_time": "2022-01-28T12:00:00.000Z",
+              "room": "Stora salongen",
+              "createdAt": "2022-01-23T10:32:07.991Z",
+              "updatedAt": "2022-01-23T10:32:07.991Z",
+              "movie": {
+                  "data": {
+                      "id": 1,
+                      "attributes": {
+                          "title": "The Shawshank Redemption",
+                          "imdbId": "tt0111161",
+                          "intro": "Two imprisoned men bond over a number of years, finding solace and eventual redemption through acts of common decency.\n\nSee more info [on IMDB](https://imdb.com/title/tt0111161)",
+                          "image": {
+                              "url": "https://m.media-amazon.com/images/M/MV5BMDFkYTc0MGEtZmNhMC00ZDIzLWFmNTEtODM1ZmRlYWMwMWFmXkEyXkFqcGdeQXVyMTMxODk2OTU@._V1_.jpg"
+                          },
+                          "createdAt": "2022-01-17T04:59:14.315Z",
+                          "updatedAt": "2022-01-18T08:47:01.417Z",
+                          "publishedAt": "2022-01-17T04:59:16.846Z"
+                      }
+                  }
+              }
+          }
+      },
+      {
+          "id": 18,
+          "attributes": {
+              "start_time": "2022-01-28T17:00:00.000Z",
+              "room": "Stora salongen",
+              "createdAt": "2022-01-23T10:32:08.517Z",
+              "updatedAt": "2022-01-23T10:32:08.517Z",
+              "movie": {
+                  "data": {
+                      "id": 1,
+                      "attributes": {
+                          "title": "The Shawshank Redemption",
+                          "imdbId": "tt0111161",
+                          "intro": "Two imprisoned men bond over a number of years, finding solace and eventual redemption through acts of common decency.\n\nSee more info [on IMDB](https://imdb.com/title/tt0111161)",
+                          "image": {
+                              "url": "https://m.media-amazon.com/images/M/MV5BMDFkYTc0MGEtZmNhMC00ZDIzLWFmNTEtODM1ZmRlYWMwMWFmXkEyXkFqcGdeQXVyMTMxODk2OTU@._V1_.jpg"
+                          },
+                          "createdAt": "2022-01-17T04:59:14.315Z",
+                          "updatedAt": "2022-01-18T08:47:01.417Z",
+                          "publishedAt": "2022-01-17T04:59:16.846Z"
+                      }
+                  }
+              }
+          }
+      },
+      {
+          "id": 19,
+          "attributes": {
+              "start_time": "2022-01-28T19:00:00.000Z",
+              "room": "Stora salongen",
+              "createdAt": "2022-01-23T10:32:09.055Z",
+              "updatedAt": "2022-01-23T10:32:09.055Z",
+              "movie": {
+                  "data": {
+                      "id": 1,
+                      "attributes": {
+                          "title": "The Shawshank Redemption",
+                          "imdbId": "tt0111161",
+                          "intro": "Two imprisoned men bond over a number of years, finding solace and eventual redemption through acts of common decency.\n\nSee more info [on IMDB](https://imdb.com/title/tt0111161)",
+                          "image": {
+                              "url": "https://m.media-amazon.com/images/M/MV5BMDFkYTc0MGEtZmNhMC00ZDIzLWFmNTEtODM1ZmRlYWMwMWFmXkEyXkFqcGdeQXVyMTMxODk2OTU@._V1_.jpg"
+                          },
+                          "createdAt": "2022-01-17T04:59:14.315Z",
+                          "updatedAt": "2022-01-18T08:47:01.417Z",
+                          "publishedAt": "2022-01-17T04:59:16.846Z"
+                      }
+                  }
+              }
+          }
+      },
+      {
+          "id": 20,
+          "attributes": {
+              "start_time": "2022-01-28T21:00:00.000Z",
+              "room": "Stora salongen",
+              "createdAt": "2022-01-23T10:32:09.591Z",
+              "updatedAt": "2022-01-23T10:32:09.591Z",
+              "movie": {
+                  "data": {
+                      "id": 2,
+                      "attributes": {
+                          "title": "The Godfather",
+                          "imdbId": "tt0068646",
+                          "intro": "The Godfather follows **Vito Corleone**, Don of the Corleone family, as he passes the mantel to his unwilling son, **Michael**.\n\nSee more info [on IMDB](https://imdb.com/title/tt0068646)",
+                          "image": {
+                              "url": "https://m.media-amazon.com/images/M/MV5BM2MyNjYxNmUtYTAwNi00MTYxLWJmNWYtYzZlODY3ZTk3OTFlXkEyXkFqcGdeQXVyNzkwMjQ5NzM@._V1_.jpg"
+                          },
+                          "createdAt": "2022-01-17T04:59:42.763Z",
+                          "updatedAt": "2022-01-18T08:47:25.840Z",
+                          "publishedAt": "2022-01-17T04:59:44.929Z"
+                      }
+                  }
+              }
+          }
+      },
+      {
+          "id": 21,
+          "attributes": {
+              "start_time": "2022-01-29T12:00:00.000Z",
+              "room": "Stora salongen",
+              "createdAt": "2022-01-23T10:32:10.131Z",
+              "updatedAt": "2022-01-23T10:32:10.131Z",
+              "movie": {
+                  "data": {
+                      "id": 10,
+                      "attributes": {
+                          "title": "Threat Level Midnight: The Movie",
+                          "imdbId": "tt11620828",
+                          "intro": "After secret agent **Michael Scarn** (played by Steve Carell) is forced into retirement due to the death of his wife **Catherine Zeta-Scarn**, the President of the United States of America (played by Craig Robinson) requests that he prevents **Goldenface** (played by John Krasinski) from blowing up the NHL All-Star Game and killing several hostages.\n\nSee more info [on IMDB](https://imdb.com/title/tt11620828)",
+                          "image": {
+                              "url": "https://m.media-amazon.com/images/M/MV5BZjMzNzE4ZGItMDI5Zi00ZjE3LThkODctYTlhZWY1ZTdmMGNjXkEyXkFqcGdeQXVyOTExNzM4NDM@._V1_.jpg"
+                          },
+                          "createdAt": "2022-01-17T10:51:45.145Z",
+                          "updatedAt": "2022-01-18T08:47:13.309Z",
+                          "publishedAt": "2022-01-17T10:51:53.355Z"
+                      }
+                  }
+              }
+          }
+      },
+      {
+          "id": 22,
+          "attributes": {
+              "start_time": "2022-01-29T17:00:00.000Z",
+              "room": "Stora salongen",
+              "createdAt": "2022-01-23T10:32:10.695Z",
+              "updatedAt": "2022-01-23T10:32:10.695Z",
+              "movie": {
+                  "data": {
+                      "id": 10,
+                      "attributes": {
+                          "title": "Threat Level Midnight: The Movie",
+                          "imdbId": "tt11620828",
+                          "intro": "After secret agent **Michael Scarn** (played by Steve Carell) is forced into retirement due to the death of his wife **Catherine Zeta-Scarn**, the President of the United States of America (played by Craig Robinson) requests that he prevents **Goldenface** (played by John Krasinski) from blowing up the NHL All-Star Game and killing several hostages.\n\nSee more info [on IMDB](https://imdb.com/title/tt11620828)",
+                          "image": {
+                              "url": "https://m.media-amazon.com/images/M/MV5BZjMzNzE4ZGItMDI5Zi00ZjE3LThkODctYTlhZWY1ZTdmMGNjXkEyXkFqcGdeQXVyOTExNzM4NDM@._V1_.jpg"
+                          },
+                          "createdAt": "2022-01-17T10:51:45.145Z",
+                          "updatedAt": "2022-01-18T08:47:13.309Z",
+                          "publishedAt": "2022-01-17T10:51:53.355Z"
+                      }
+                  }
+              }
+          }
+      },
+      {
+          "id": 23,
+          "attributes": {
+              "start_time": "2022-01-29T19:00:00.000Z",
+              "room": "Stora salongen",
+              "createdAt": "2022-01-23T10:32:11.239Z",
+              "updatedAt": "2022-01-23T10:32:11.239Z",
+              "movie": {
+                  "data": {
+                      "id": 2,
+                      "attributes": {
+                          "title": "The Godfather",
+                          "imdbId": "tt0068646",
+                          "intro": "The Godfather follows **Vito Corleone**, Don of the Corleone family, as he passes the mantel to his unwilling son, **Michael**.\n\nSee more info [on IMDB](https://imdb.com/title/tt0068646)",
+                          "image": {
+                              "url": "https://m.media-amazon.com/images/M/MV5BM2MyNjYxNmUtYTAwNi00MTYxLWJmNWYtYzZlODY3ZTk3OTFlXkEyXkFqcGdeQXVyNzkwMjQ5NzM@._V1_.jpg"
+                          },
+                          "createdAt": "2022-01-17T04:59:42.763Z",
+                          "updatedAt": "2022-01-18T08:47:25.840Z",
+                          "publishedAt": "2022-01-17T04:59:44.929Z"
+                      }
+                  }
+              }
+          }
+      },
+      {
+          "id": 24,
+          "attributes": {
+              "start_time": "2022-01-29T21:00:00.000Z",
+              "room": "Stora salongen",
+              "createdAt": "2022-01-23T10:32:11.766Z",
+              "updatedAt": "2022-01-23T10:32:11.766Z",
+              "movie": {
+                  "data": {
+                      "id": 1,
+                      "attributes": {
+                          "title": "The Shawshank Redemption",
+                          "imdbId": "tt0111161",
+                          "intro": "Two imprisoned men bond over a number of years, finding solace and eventual redemption through acts of common decency.\n\nSee more info [on IMDB](https://imdb.com/title/tt0111161)",
+                          "image": {
+                              "url": "https://m.media-amazon.com/images/M/MV5BMDFkYTc0MGEtZmNhMC00ZDIzLWFmNTEtODM1ZmRlYWMwMWFmXkEyXkFqcGdeQXVyMTMxODk2OTU@._V1_.jpg"
+                          },
+                          "createdAt": "2022-01-17T04:59:14.315Z",
+                          "updatedAt": "2022-01-18T08:47:01.417Z",
+                          "publishedAt": "2022-01-17T04:59:16.846Z"
+                      }
+                  }
+              }
+          }
+      },
+      {
+          "id": 25,
+          "attributes": {
+              "start_time": "2022-01-30T12:00:00.000Z",
+              "room": "Stora salongen",
+              "createdAt": "2022-01-23T10:32:12.316Z",
+              "updatedAt": "2022-01-23T10:32:12.316Z",
+              "movie": {
+                  "data": {
+                      "id": 2,
+                      "attributes": {
+                          "title": "The Godfather",
+                          "imdbId": "tt0068646",
+                          "intro": "The Godfather follows **Vito Corleone**, Don of the Corleone family, as he passes the mantel to his unwilling son, **Michael**.\n\nSee more info [on IMDB](https://imdb.com/title/tt0068646)",
+                          "image": {
+                              "url": "https://m.media-amazon.com/images/M/MV5BM2MyNjYxNmUtYTAwNi00MTYxLWJmNWYtYzZlODY3ZTk3OTFlXkEyXkFqcGdeQXVyNzkwMjQ5NzM@._V1_.jpg"
+                          },
+                          "createdAt": "2022-01-17T04:59:42.763Z",
+                          "updatedAt": "2022-01-18T08:47:25.840Z",
+                          "publishedAt": "2022-01-17T04:59:44.929Z"
+                      }
+                  }
+              }
+          }
+      },
+      {
+          "id": 26,
+          "attributes": {
+              "start_time": "2022-01-30T17:00:00.000Z",
+              "room": "Stora salongen",
+              "createdAt": "2022-01-23T10:32:12.918Z",
+              "updatedAt": "2022-01-23T10:32:12.918Z",
+              "movie": {
+                  "data": {
+                      "id": 2,
+                      "attributes": {
+                          "title": "The Godfather",
+                          "imdbId": "tt0068646",
+                          "intro": "The Godfather follows **Vito Corleone**, Don of the Corleone family, as he passes the mantel to his unwilling son, **Michael**.\n\nSee more info [on IMDB](https://imdb.com/title/tt0068646)",
+                          "image": {
+                              "url": "https://m.media-amazon.com/images/M/MV5BM2MyNjYxNmUtYTAwNi00MTYxLWJmNWYtYzZlODY3ZTk3OTFlXkEyXkFqcGdeQXVyNzkwMjQ5NzM@._V1_.jpg"
+                          },
+                          "createdAt": "2022-01-17T04:59:42.763Z",
+                          "updatedAt": "2022-01-18T08:47:25.840Z",
+                          "publishedAt": "2022-01-17T04:59:44.929Z"
+                      }
+                  }
+              }
+          }
+      },
+      {
+          "id": 27,
+          "attributes": {
+              "start_time": "2022-01-30T19:00:00.000Z",
+              "room": "Stora salongen",
+              "createdAt": "2022-01-23T10:32:13.489Z",
+              "updatedAt": "2022-01-23T10:32:13.489Z",
+              "movie": {
+                  "data": {
+                      "id": 3,
+                      "attributes": {
+                          "title": "The Godfather: Part II",
+                          "imdbId": "tt0071562",
+                          "intro": "The early life and career of **Vito Corleone** in 1920s New York City is portrayed, while his son, **Michael**, expands and tightens his grip on the family crime syndicate.\n\nSee more info [on IMDB](https://imdb.com/title/tt0071562)",
+                          "image": {
+                              "url": "https://m.media-amazon.com/images/M/MV5BMWMwMGQzZTItY2JlNC00OWZiLWIyMDctNDk2ZDQ2YjRjMWQ0XkEyXkFqcGdeQXVyNzkwMjQ5NzM@._V1_.jpg"
+                          },
+                          "createdAt": "2022-01-17T05:00:31.562Z",
+                          "updatedAt": "2022-01-18T08:46:47.388Z",
+                          "publishedAt": "2022-01-17T05:00:33.453Z"
+                      }
+                  }
+              }
+          }
+      },
+      {
+          "id": 28,
+          "attributes": {
+              "start_time": "2022-01-30T21:00:00.000Z",
+              "room": "Stora salongen",
+              "createdAt": "2022-01-23T10:32:14.039Z",
+              "updatedAt": "2022-01-23T10:32:14.039Z",
+              "movie": {
+                  "data": {
+                      "id": 2,
+                      "attributes": {
+                          "title": "The Godfather",
+                          "imdbId": "tt0068646",
+                          "intro": "The Godfather follows **Vito Corleone**, Don of the Corleone family, as he passes the mantel to his unwilling son, **Michael**.\n\nSee more info [on IMDB](https://imdb.com/title/tt0068646)",
+                          "image": {
+                              "url": "https://m.media-amazon.com/images/M/MV5BM2MyNjYxNmUtYTAwNi00MTYxLWJmNWYtYzZlODY3ZTk3OTFlXkEyXkFqcGdeQXVyNzkwMjQ5NzM@._V1_.jpg"
+                          },
+                          "createdAt": "2022-01-17T04:59:42.763Z",
+                          "updatedAt": "2022-01-18T08:47:25.840Z",
+                          "publishedAt": "2022-01-17T04:59:44.929Z"
+                      }
+                  }
+              }
+          }
+      },
+      {
+          "id": 29,
+          "attributes": {
+              "start_time": "2022-01-31T12:00:00.000Z",
+              "room": "Stora salongen",
+              "createdAt": "2022-01-23T10:32:14.668Z",
+              "updatedAt": "2022-01-23T10:32:14.668Z",
+              "movie": {
+                  "data": {
+                      "id": 10,
+                      "attributes": {
+                          "title": "Threat Level Midnight: The Movie",
+                          "imdbId": "tt11620828",
+                          "intro": "After secret agent **Michael Scarn** (played by Steve Carell) is forced into retirement due to the death of his wife **Catherine Zeta-Scarn**, the President of the United States of America (played by Craig Robinson) requests that he prevents **Goldenface** (played by John Krasinski) from blowing up the NHL All-Star Game and killing several hostages.\n\nSee more info [on IMDB](https://imdb.com/title/tt11620828)",
+                          "image": {
+                              "url": "https://m.media-amazon.com/images/M/MV5BZjMzNzE4ZGItMDI5Zi00ZjE3LThkODctYTlhZWY1ZTdmMGNjXkEyXkFqcGdeQXVyOTExNzM4NDM@._V1_.jpg"
+                          },
+                          "createdAt": "2022-01-17T10:51:45.145Z",
+                          "updatedAt": "2022-01-18T08:47:13.309Z",
+                          "publishedAt": "2022-01-17T10:51:53.355Z"
+                      }
+                  }
+              }
+          }
+      },
+      {
+          "id": 30,
+          "attributes": {
+              "start_time": "2022-01-31T17:00:00.000Z",
+              "room": "Stora salongen",
+              "createdAt": "2022-01-23T10:32:15.220Z",
+              "updatedAt": "2022-01-23T10:32:15.220Z",
+              "movie": {
+                  "data": {
+                      "id": 2,
+                      "attributes": {
+                          "title": "The Godfather",
+                          "imdbId": "tt0068646",
+                          "intro": "The Godfather follows **Vito Corleone**, Don of the Corleone family, as he passes the mantel to his unwilling son, **Michael**.\n\nSee more info [on IMDB](https://imdb.com/title/tt0068646)",
+                          "image": {
+                              "url": "https://m.media-amazon.com/images/M/MV5BM2MyNjYxNmUtYTAwNi00MTYxLWJmNWYtYzZlODY3ZTk3OTFlXkEyXkFqcGdeQXVyNzkwMjQ5NzM@._V1_.jpg"
+                          },
+                          "createdAt": "2022-01-17T04:59:42.763Z",
+                          "updatedAt": "2022-01-18T08:47:25.840Z",
+                          "publishedAt": "2022-01-17T04:59:44.929Z"
+                      }
+                  }
+              }
+          }
+      },
+      {
+          "id": 31,
+          "attributes": {
+              "start_time": "2022-01-31T19:00:00.000Z",
+              "room": "Stora salongen",
+              "createdAt": "2022-01-23T10:32:15.771Z",
+              "updatedAt": "2022-01-23T10:32:15.771Z",
+              "movie": {
+                  "data": {
+                      "id": 4,
+                      "attributes": {
+                          "title": "The Dark Knight",
+                          "imdbId": "tt0468569",
+                          "intro": "When the menace known as the Joker wreaks havoc and chaos on the people of Gotham, **Batman** must accept one of the greatest psychological and physical tests of his ability to fight injustice.\n\nSee more info [on IMDB](https://imdb.com/title/tt0468569)",
+                          "image": {
+                              "url": "https://m.media-amazon.com/images/M/MV5BMTMxNTMwODM0NF5BMl5BanBnXkFtZTcwODAyMTk2Mw@@._V1_.jpg"
+                          },
+                          "createdAt": "2022-01-17T05:00:58.423Z",
+                          "updatedAt": "2022-01-18T08:47:52.866Z",
+                          "publishedAt": "2022-01-17T05:01:00.594Z"
+                      }
+                  }
+              }
+          }
+      },
+      {
+          "id": 32,
+          "attributes": {
+              "start_time": "2022-01-31T21:00:00.000Z",
+              "room": "Stora salongen",
+              "createdAt": "2022-01-23T10:32:16.822Z",
+              "updatedAt": "2022-01-23T10:32:16.822Z",
+              "movie": {
+                  "data": {
+                      "id": 2,
+                      "attributes": {
+                          "title": "The Godfather",
+                          "imdbId": "tt0068646",
+                          "intro": "The Godfather follows **Vito Corleone**, Don of the Corleone family, as he passes the mantel to his unwilling son, **Michael**.\n\nSee more info [on IMDB](https://imdb.com/title/tt0068646)",
+                          "image": {
+                              "url": "https://m.media-amazon.com/images/M/MV5BM2MyNjYxNmUtYTAwNi00MTYxLWJmNWYtYzZlODY3ZTk3OTFlXkEyXkFqcGdeQXVyNzkwMjQ5NzM@._V1_.jpg"
+                          },
+                          "createdAt": "2022-01-17T04:59:42.763Z",
+                          "updatedAt": "2022-01-18T08:47:25.840Z",
+                          "publishedAt": "2022-01-17T04:59:44.929Z"
+                      }
+                  }
+              }
+          }
+      },
+      {
+          "id": 33,
+          "attributes": {
+              "start_time": "2022-02-01T12:00:00.000Z",
+              "room": "Stora salongen",
+              "createdAt": "2022-01-23T10:32:17.391Z",
+              "updatedAt": "2022-01-23T10:32:17.391Z",
+              "movie": {
+                  "data": {
+                      "id": 8,
+                      "attributes": {
+                          "title": "Idiocracy",
+                          "imdbId": "tt0387808",
+                          "intro": "Private **Joe Bauers**, a decisively average American, is selected as a guinea pig for a top-secret hibernation program but is forgotten, awakening to a future so incredibly moronic he's easily the most intelligent person alive.\n\nSee more info [on IMDB](https://imdb.com/title/tt0387808)",
+                          "image": {
+                              "url": "https://m.media-amazon.com/images/M/MV5BMWQ4MzI2ZDQtYjk3MS00ODdjLTkwN2QtOTBjYzIwM2RmNzgyXkEyXkFqcGdeQXVyMTQxNzMzNDI@._V1_.jpg"
+                          },
+                          "createdAt": "2022-01-17T09:32:08.570Z",
+                          "updatedAt": "2022-01-18T08:48:02.876Z",
+                          "publishedAt": "2022-01-17T09:32:12.868Z"
+                      }
+                  }
+              }
+          }
+      },
+      {
+          "id": 34,
+          "attributes": {
+              "start_time": "2022-02-01T17:00:00.000Z",
+              "room": "Stora salongen",
+              "createdAt": "2022-01-23T10:32:17.954Z",
+              "updatedAt": "2022-01-23T10:32:17.954Z",
+              "movie": {
+                  "data": {
+                      "id": 1,
+                      "attributes": {
+                          "title": "The Shawshank Redemption",
+                          "imdbId": "tt0111161",
+                          "intro": "Two imprisoned men bond over a number of years, finding solace and eventual redemption through acts of common decency.\n\nSee more info [on IMDB](https://imdb.com/title/tt0111161)",
+                          "image": {
+                              "url": "https://m.media-amazon.com/images/M/MV5BMDFkYTc0MGEtZmNhMC00ZDIzLWFmNTEtODM1ZmRlYWMwMWFmXkEyXkFqcGdeQXVyMTMxODk2OTU@._V1_.jpg"
+                          },
+                          "createdAt": "2022-01-17T04:59:14.315Z",
+                          "updatedAt": "2022-01-18T08:47:01.417Z",
+                          "publishedAt": "2022-01-17T04:59:16.846Z"
+                      }
+                  }
+              }
+          }
+      },
+      {
+          "id": 35,
+          "attributes": {
+              "start_time": "2022-02-01T19:00:00.000Z",
+              "room": "Stora salongen",
+              "createdAt": "2022-01-23T10:32:18.516Z",
+              "updatedAt": "2022-01-23T10:32:18.516Z",
+              "movie": {
+                  "data": {
+                      "id": 3,
+                      "attributes": {
+                          "title": "The Godfather: Part II",
+                          "imdbId": "tt0071562",
+                          "intro": "The early life and career of **Vito Corleone** in 1920s New York City is portrayed, while his son, **Michael**, expands and tightens his grip on the family crime syndicate.\n\nSee more info [on IMDB](https://imdb.com/title/tt0071562)",
+                          "image": {
+                              "url": "https://m.media-amazon.com/images/M/MV5BMWMwMGQzZTItY2JlNC00OWZiLWIyMDctNDk2ZDQ2YjRjMWQ0XkEyXkFqcGdeQXVyNzkwMjQ5NzM@._V1_.jpg"
+                          },
+                          "createdAt": "2022-01-17T05:00:31.562Z",
+                          "updatedAt": "2022-01-18T08:46:47.388Z",
+                          "publishedAt": "2022-01-17T05:00:33.453Z"
+                      }
+                  }
+              }
+          }
+      },
+      {
+          "id": 36,
+          "attributes": {
+              "start_time": "2022-02-01T21:00:00.000Z",
+              "room": "Stora salongen",
+              "createdAt": "2022-01-23T10:32:19.051Z",
+              "updatedAt": "2022-01-23T10:32:19.051Z",
+              "movie": {
+                  "data": {
+                      "id": 2,
+                      "attributes": {
+                          "title": "The Godfather",
+                          "imdbId": "tt0068646",
+                          "intro": "The Godfather follows **Vito Corleone**, Don of the Corleone family, as he passes the mantel to his unwilling son, **Michael**.\n\nSee more info [on IMDB](https://imdb.com/title/tt0068646)",
+                          "image": {
+                              "url": "https://m.media-amazon.com/images/M/MV5BM2MyNjYxNmUtYTAwNi00MTYxLWJmNWYtYzZlODY3ZTk3OTFlXkEyXkFqcGdeQXVyNzkwMjQ5NzM@._V1_.jpg"
+                          },
+                          "createdAt": "2022-01-17T04:59:42.763Z",
+                          "updatedAt": "2022-01-18T08:47:25.840Z",
+                          "publishedAt": "2022-01-17T04:59:44.929Z"
+                      }
+                  }
+              }
+          }
+      },
+      {
+          "id": 37,
+          "attributes": {
+              "start_time": "2022-02-02T12:00:00.000Z",
+              "room": "Stora salongen",
+              "createdAt": "2022-01-23T10:32:19.612Z",
+              "updatedAt": "2022-01-23T10:32:19.612Z",
+              "movie": {
+                  "data": {
+                      "id": 8,
+                      "attributes": {
+                          "title": "Idiocracy",
+                          "imdbId": "tt0387808",
+                          "intro": "Private **Joe Bauers**, a decisively average American, is selected as a guinea pig for a top-secret hibernation program but is forgotten, awakening to a future so incredibly moronic he's easily the most intelligent person alive.\n\nSee more info [on IMDB](https://imdb.com/title/tt0387808)",
+                          "image": {
+                              "url": "https://m.media-amazon.com/images/M/MV5BMWQ4MzI2ZDQtYjk3MS00ODdjLTkwN2QtOTBjYzIwM2RmNzgyXkEyXkFqcGdeQXVyMTQxNzMzNDI@._V1_.jpg"
+                          },
+                          "createdAt": "2022-01-17T09:32:08.570Z",
+                          "updatedAt": "2022-01-18T08:48:02.876Z",
+                          "publishedAt": "2022-01-17T09:32:12.868Z"
+                      }
+                  }
+              }
+          }
+      },
+      {
+          "id": 38,
+          "attributes": {
+              "start_time": "2022-02-02T17:00:00.000Z",
+              "room": "Stora salongen",
+              "createdAt": "2022-01-23T10:32:20.188Z",
+              "updatedAt": "2022-01-23T10:32:20.188Z",
+              "movie": {
+                  "data": {
+                      "id": 2,
+                      "attributes": {
+                          "title": "The Godfather",
+                          "imdbId": "tt0068646",
+                          "intro": "The Godfather follows **Vito Corleone**, Don of the Corleone family, as he passes the mantel to his unwilling son, **Michael**.\n\nSee more info [on IMDB](https://imdb.com/title/tt0068646)",
+                          "image": {
+                              "url": "https://m.media-amazon.com/images/M/MV5BM2MyNjYxNmUtYTAwNi00MTYxLWJmNWYtYzZlODY3ZTk3OTFlXkEyXkFqcGdeQXVyNzkwMjQ5NzM@._V1_.jpg"
+                          },
+                          "createdAt": "2022-01-17T04:59:42.763Z",
+                          "updatedAt": "2022-01-18T08:47:25.840Z",
+                          "publishedAt": "2022-01-17T04:59:44.929Z"
+                      }
+                  }
+              }
+          }
+      },
+      {
+          "id": 39,
+          "attributes": {
+              "start_time": "2022-02-02T19:00:00.000Z",
+              "room": "Stora salongen",
+              "createdAt": "2022-01-23T10:32:20.722Z",
+              "updatedAt": "2022-01-23T10:32:20.722Z",
+              "movie": {
+                  "data": {
+                      "id": 4,
+                      "attributes": {
+                          "title": "The Dark Knight",
+                          "imdbId": "tt0468569",
+                          "intro": "When the menace known as the Joker wreaks havoc and chaos on the people of Gotham, **Batman** must accept one of the greatest psychological and physical tests of his ability to fight injustice.\n\nSee more info [on IMDB](https://imdb.com/title/tt0468569)",
+                          "image": {
+                              "url": "https://m.media-amazon.com/images/M/MV5BMTMxNTMwODM0NF5BMl5BanBnXkFtZTcwODAyMTk2Mw@@._V1_.jpg"
+                          },
+                          "createdAt": "2022-01-17T05:00:58.423Z",
+                          "updatedAt": "2022-01-18T08:47:52.866Z",
+                          "publishedAt": "2022-01-17T05:01:00.594Z"
+                      }
+                  }
+              }
+          }
+      },
+      {
+          "id": 40,
+          "attributes": {
+              "start_time": "2022-02-02T21:00:00.000Z",
+              "room": "Stora salongen",
+              "createdAt": "2022-01-23T10:32:21.266Z",
+              "updatedAt": "2022-01-23T10:32:21.266Z",
+              "movie": {
+                  "data": {
+                      "id": 1,
+                      "attributes": {
+                          "title": "The Shawshank Redemption",
+                          "imdbId": "tt0111161",
+                          "intro": "Two imprisoned men bond over a number of years, finding solace and eventual redemption through acts of common decency.\n\nSee more info [on IMDB](https://imdb.com/title/tt0111161)",
+                          "image": {
+                              "url": "https://m.media-amazon.com/images/M/MV5BMDFkYTc0MGEtZmNhMC00ZDIzLWFmNTEtODM1ZmRlYWMwMWFmXkEyXkFqcGdeQXVyMTMxODk2OTU@._V1_.jpg"
+                          },
+                          "createdAt": "2022-01-17T04:59:14.315Z",
+                          "updatedAt": "2022-01-18T08:47:01.417Z",
+                          "publishedAt": "2022-01-17T04:59:16.846Z"
+                      }
+                  }
+              }
+          }
+      },
+      {
+          "id": 41,
+          "attributes": {
+              "start_time": "2022-02-03T12:00:00.000Z",
+              "room": "Stora salongen",
+              "createdAt": "2022-01-23T10:32:21.864Z",
+              "updatedAt": "2022-01-23T10:32:21.864Z",
+              "movie": {
+                  "data": {
+                      "id": 1,
+                      "attributes": {
+                          "title": "The Shawshank Redemption",
+                          "imdbId": "tt0111161",
+                          "intro": "Two imprisoned men bond over a number of years, finding solace and eventual redemption through acts of common decency.\n\nSee more info [on IMDB](https://imdb.com/title/tt0111161)",
+                          "image": {
+                              "url": "https://m.media-amazon.com/images/M/MV5BMDFkYTc0MGEtZmNhMC00ZDIzLWFmNTEtODM1ZmRlYWMwMWFmXkEyXkFqcGdeQXVyMTMxODk2OTU@._V1_.jpg"
+                          },
+                          "createdAt": "2022-01-17T04:59:14.315Z",
+                          "updatedAt": "2022-01-18T08:47:01.417Z",
+                          "publishedAt": "2022-01-17T04:59:16.846Z"
+                      }
+                  }
+              }
+          }
+      },
+      {
+          "id": 42,
+          "attributes": {
+              "start_time": "2022-02-03T17:00:00.000Z",
+              "room": "Stora salongen",
+              "createdAt": "2022-01-23T10:32:22.392Z",
+              "updatedAt": "2022-01-23T10:32:22.392Z",
+              "movie": {
+                  "data": {
+                      "id": 5,
+                      "attributes": {
+                          "title": "12 Angry Men",
+                          "imdbId": "tt0050083",
+                          "intro": "The jury in a New York City murder trial is frustrated by a single member whose skeptical caution forces them to more carefully consider the evidence before jumping to a hasty verdict.\n\nSee more info [on IMDB](https://imdb.com/title/tt0050083)",
+                          "image": {
+                              "url": "https://m.media-amazon.com/images/M/MV5BMWU4N2FjNzYtNTVkNC00NzQ0LTg0MjAtYTJlMjFhNGUxZDFmXkEyXkFqcGdeQXVyNjc1NTYyMjg@._V1_.jpg"
+                          },
+                          "createdAt": "2022-01-17T05:01:21.807Z",
+                          "updatedAt": "2022-01-18T08:48:15.429Z",
+                          "publishedAt": "2022-01-17T05:01:24.036Z"
+                      }
+                  }
+              }
+          }
+      },
+      {
+          "id": 43,
+          "attributes": {
+              "start_time": "2022-02-03T19:00:00.000Z",
+              "room": "Stora salongen",
+              "createdAt": "2022-01-23T10:32:22.955Z",
+              "updatedAt": "2022-01-23T10:32:22.955Z",
+              "movie": {
+                  "data": {
+                      "id": 2,
+                      "attributes": {
+                          "title": "The Godfather",
+                          "imdbId": "tt0068646",
+                          "intro": "The Godfather follows **Vito Corleone**, Don of the Corleone family, as he passes the mantel to his unwilling son, **Michael**.\n\nSee more info [on IMDB](https://imdb.com/title/tt0068646)",
+                          "image": {
+                              "url": "https://m.media-amazon.com/images/M/MV5BM2MyNjYxNmUtYTAwNi00MTYxLWJmNWYtYzZlODY3ZTk3OTFlXkEyXkFqcGdeQXVyNzkwMjQ5NzM@._V1_.jpg"
+                          },
+                          "createdAt": "2022-01-17T04:59:42.763Z",
+                          "updatedAt": "2022-01-18T08:47:25.840Z",
+                          "publishedAt": "2022-01-17T04:59:44.929Z"
+                      }
+                  }
+              }
+          }
+      },
+      {
+          "id": 44,
+          "attributes": {
+              "start_time": "2022-02-03T21:00:00.000Z",
+              "room": "Stora salongen",
+              "createdAt": "2022-01-23T10:32:23.740Z",
+              "updatedAt": "2022-01-23T10:32:23.740Z",
+              "movie": {
+                  "data": {
+                      "id": 3,
+                      "attributes": {
+                          "title": "The Godfather: Part II",
+                          "imdbId": "tt0071562",
+                          "intro": "The early life and career of **Vito Corleone** in 1920s New York City is portrayed, while his son, **Michael**, expands and tightens his grip on the family crime syndicate.\n\nSee more info [on IMDB](https://imdb.com/title/tt0071562)",
+                          "image": {
+                              "url": "https://m.media-amazon.com/images/M/MV5BMWMwMGQzZTItY2JlNC00OWZiLWIyMDctNDk2ZDQ2YjRjMWQ0XkEyXkFqcGdeQXVyNzkwMjQ5NzM@._V1_.jpg"
+                          },
+                          "createdAt": "2022-01-17T05:00:31.562Z",
+                          "updatedAt": "2022-01-18T08:46:47.388Z",
+                          "publishedAt": "2022-01-17T05:00:33.453Z"
+                      }
+                  }
+              }
+          }
+      },
+      {
+          "id": 45,
+          "attributes": {
+              "start_time": "2022-02-04T12:00:00.000Z",
+              "room": "Stora salongen",
+              "createdAt": "2022-01-23T10:32:24.272Z",
+              "updatedAt": "2022-01-23T10:32:24.272Z",
+              "movie": {
+                  "data": {
+                      "id": 5,
+                      "attributes": {
+                          "title": "12 Angry Men",
+                          "imdbId": "tt0050083",
+                          "intro": "The jury in a New York City murder trial is frustrated by a single member whose skeptical caution forces them to more carefully consider the evidence before jumping to a hasty verdict.\n\nSee more info [on IMDB](https://imdb.com/title/tt0050083)",
+                          "image": {
+                              "url": "https://m.media-amazon.com/images/M/MV5BMWU4N2FjNzYtNTVkNC00NzQ0LTg0MjAtYTJlMjFhNGUxZDFmXkEyXkFqcGdeQXVyNjc1NTYyMjg@._V1_.jpg"
+                          },
+                          "createdAt": "2022-01-17T05:01:21.807Z",
+                          "updatedAt": "2022-01-18T08:48:15.429Z",
+                          "publishedAt": "2022-01-17T05:01:24.036Z"
+                      }
+                  }
+              }
+          }
+      },
+      {
+          "id": 46,
+          "attributes": {
+              "start_time": "2022-02-04T17:00:00.000Z",
+              "room": "Stora salongen",
+              "createdAt": "2022-01-23T10:32:24.811Z",
+              "updatedAt": "2022-01-23T10:32:24.811Z",
+              "movie": {
+                  "data": {
+                      "id": 3,
+                      "attributes": {
+                          "title": "The Godfather: Part II",
+                          "imdbId": "tt0071562",
+                          "intro": "The early life and career of **Vito Corleone** in 1920s New York City is portrayed, while his son, **Michael**, expands and tightens his grip on the family crime syndicate.\n\nSee more info [on IMDB](https://imdb.com/title/tt0071562)",
+                          "image": {
+                              "url": "https://m.media-amazon.com/images/M/MV5BMWMwMGQzZTItY2JlNC00OWZiLWIyMDctNDk2ZDQ2YjRjMWQ0XkEyXkFqcGdeQXVyNzkwMjQ5NzM@._V1_.jpg"
+                          },
+                          "createdAt": "2022-01-17T05:00:31.562Z",
+                          "updatedAt": "2022-01-18T08:46:47.388Z",
+                          "publishedAt": "2022-01-17T05:00:33.453Z"
+                      }
+                  }
+              }
+          }
+      },
+      {
+          "id": 47,
+          "attributes": {
+              "start_time": "2022-02-04T19:00:00.000Z",
+              "room": "Stora salongen",
+              "createdAt": "2022-01-23T10:32:25.382Z",
+              "updatedAt": "2022-01-23T10:32:25.382Z",
+              "movie": {
+                  "data": {
+                      "id": 1,
+                      "attributes": {
+                          "title": "The Shawshank Redemption",
+                          "imdbId": "tt0111161",
+                          "intro": "Two imprisoned men bond over a number of years, finding solace and eventual redemption through acts of common decency.\n\nSee more info [on IMDB](https://imdb.com/title/tt0111161)",
+                          "image": {
+                              "url": "https://m.media-amazon.com/images/M/MV5BMDFkYTc0MGEtZmNhMC00ZDIzLWFmNTEtODM1ZmRlYWMwMWFmXkEyXkFqcGdeQXVyMTMxODk2OTU@._V1_.jpg"
+                          },
+                          "createdAt": "2022-01-17T04:59:14.315Z",
+                          "updatedAt": "2022-01-18T08:47:01.417Z",
+                          "publishedAt": "2022-01-17T04:59:16.846Z"
+                      }
+                  }
+              }
+          }
+      },
+      {
+          "id": 48,
+          "attributes": {
+              "start_time": "2022-02-04T21:00:00.000Z",
+              "room": "Stora salongen",
+              "createdAt": "2022-01-23T10:32:25.918Z",
+              "updatedAt": "2022-01-23T10:32:25.918Z",
+              "movie": {
+                  "data": {
+                      "id": 4,
+                      "attributes": {
+                          "title": "The Dark Knight",
+                          "imdbId": "tt0468569",
+                          "intro": "When the menace known as the Joker wreaks havoc and chaos on the people of Gotham, **Batman** must accept one of the greatest psychological and physical tests of his ability to fight injustice.\n\nSee more info [on IMDB](https://imdb.com/title/tt0468569)",
+                          "image": {
+                              "url": "https://m.media-amazon.com/images/M/MV5BMTMxNTMwODM0NF5BMl5BanBnXkFtZTcwODAyMTk2Mw@@._V1_.jpg"
+                          },
+                          "createdAt": "2022-01-17T05:00:58.423Z",
+                          "updatedAt": "2022-01-18T08:47:52.866Z",
+                          "publishedAt": "2022-01-17T05:01:00.594Z"
+                      }
+                  }
+              }
+          }
+      },
+      {
+          "id": 49,
+          "attributes": {
+              "start_time": "2022-02-05T12:00:00.000Z",
+              "room": "Stora salongen",
+              "createdAt": "2022-01-23T10:32:26.441Z",
+              "updatedAt": "2022-01-23T10:32:26.441Z",
+              "movie": {
+                  "data": {
+                      "id": 5,
+                      "attributes": {
+                          "title": "12 Angry Men",
+                          "imdbId": "tt0050083",
+                          "intro": "The jury in a New York City murder trial is frustrated by a single member whose skeptical caution forces them to more carefully consider the evidence before jumping to a hasty verdict.\n\nSee more info [on IMDB](https://imdb.com/title/tt0050083)",
+                          "image": {
+                              "url": "https://m.media-amazon.com/images/M/MV5BMWU4N2FjNzYtNTVkNC00NzQ0LTg0MjAtYTJlMjFhNGUxZDFmXkEyXkFqcGdeQXVyNjc1NTYyMjg@._V1_.jpg"
+                          },
+                          "createdAt": "2022-01-17T05:01:21.807Z",
+                          "updatedAt": "2022-01-18T08:48:15.429Z",
+                          "publishedAt": "2022-01-17T05:01:24.036Z"
+                      }
+                  }
+              }
+          }
+      },
+      {
+          "id": 50,
+          "attributes": {
+              "start_time": "2022-02-05T17:00:00.000Z",
+              "room": "Stora salongen",
+              "createdAt": "2022-01-23T10:32:26.971Z",
+              "updatedAt": "2022-01-23T10:32:26.971Z",
+              "movie": {
+                  "data": {
+                      "id": 8,
+                      "attributes": {
+                          "title": "Idiocracy",
+                          "imdbId": "tt0387808",
+                          "intro": "Private **Joe Bauers**, a decisively average American, is selected as a guinea pig for a top-secret hibernation program but is forgotten, awakening to a future so incredibly moronic he's easily the most intelligent person alive.\n\nSee more info [on IMDB](https://imdb.com/title/tt0387808)",
+                          "image": {
+                              "url": "https://m.media-amazon.com/images/M/MV5BMWQ4MzI2ZDQtYjk3MS00ODdjLTkwN2QtOTBjYzIwM2RmNzgyXkEyXkFqcGdeQXVyMTQxNzMzNDI@._V1_.jpg"
+                          },
+                          "createdAt": "2022-01-17T09:32:08.570Z",
+                          "updatedAt": "2022-01-18T08:48:02.876Z",
+                          "publishedAt": "2022-01-17T09:32:12.868Z"
+                      }
+                  }
+              }
+          }
+      },
+      {
+          "id": 51,
+          "attributes": {
+              "start_time": "2022-02-05T19:00:00.000Z",
+              "room": "Stora salongen",
+              "createdAt": "2022-01-23T10:32:27.507Z",
+              "updatedAt": "2022-01-23T10:32:27.507Z",
+              "movie": {
+                  "data": {
+                      "id": 10,
+                      "attributes": {
+                          "title": "Threat Level Midnight: The Movie",
+                          "imdbId": "tt11620828",
+                          "intro": "After secret agent **Michael Scarn** (played by Steve Carell) is forced into retirement due to the death of his wife **Catherine Zeta-Scarn**, the President of the United States of America (played by Craig Robinson) requests that he prevents **Goldenface** (played by John Krasinski) from blowing up the NHL All-Star Game and killing several hostages.\n\nSee more info [on IMDB](https://imdb.com/title/tt11620828)",
+                          "image": {
+                              "url": "https://m.media-amazon.com/images/M/MV5BZjMzNzE4ZGItMDI5Zi00ZjE3LThkODctYTlhZWY1ZTdmMGNjXkEyXkFqcGdeQXVyOTExNzM4NDM@._V1_.jpg"
+                          },
+                          "createdAt": "2022-01-17T10:51:45.145Z",
+                          "updatedAt": "2022-01-18T08:47:13.309Z",
+                          "publishedAt": "2022-01-17T10:51:53.355Z"
+                      }
+                  }
+              }
+          }
+      },
+      {
+          "id": 52,
+          "attributes": {
+              "start_time": "2022-02-05T21:00:00.000Z",
+              "room": "Stora salongen",
+              "createdAt": "2022-01-23T10:32:28.083Z",
+              "updatedAt": "2022-01-23T10:32:28.083Z",
+              "movie": {
+                  "data": {
+                      "id": 4,
+                      "attributes": {
+                          "title": "The Dark Knight",
+                          "imdbId": "tt0468569",
+                          "intro": "When the menace known as the Joker wreaks havoc and chaos on the people of Gotham, **Batman** must accept one of the greatest psychological and physical tests of his ability to fight injustice.\n\nSee more info [on IMDB](https://imdb.com/title/tt0468569)",
+                          "image": {
+                              "url": "https://m.media-amazon.com/images/M/MV5BMTMxNTMwODM0NF5BMl5BanBnXkFtZTcwODAyMTk2Mw@@._V1_.jpg"
+                          },
+                          "createdAt": "2022-01-17T05:00:58.423Z",
+                          "updatedAt": "2022-01-18T08:47:52.866Z",
+                          "publishedAt": "2022-01-17T05:01:00.594Z"
+                      }
+                  }
+              }
+          }
+      },
+      {
+          "id": 53,
+          "attributes": {
+              "start_time": "2022-02-06T12:00:00.000Z",
+              "room": "Stora salongen",
+              "createdAt": "2022-01-23T10:32:28.663Z",
+              "updatedAt": "2022-01-23T10:32:28.663Z",
+              "movie": {
+                  "data": {
+                      "id": 5,
+                      "attributes": {
+                          "title": "12 Angry Men",
+                          "imdbId": "tt0050083",
+                          "intro": "The jury in a New York City murder trial is frustrated by a single member whose skeptical caution forces them to more carefully consider the evidence before jumping to a hasty verdict.\n\nSee more info [on IMDB](https://imdb.com/title/tt0050083)",
+                          "image": {
+                              "url": "https://m.media-amazon.com/images/M/MV5BMWU4N2FjNzYtNTVkNC00NzQ0LTg0MjAtYTJlMjFhNGUxZDFmXkEyXkFqcGdeQXVyNjc1NTYyMjg@._V1_.jpg"
+                          },
+                          "createdAt": "2022-01-17T05:01:21.807Z",
+                          "updatedAt": "2022-01-18T08:48:15.429Z",
+                          "publishedAt": "2022-01-17T05:01:24.036Z"
+                      }
+                  }
+              }
+          }
+      },
+      {
+          "id": 54,
+          "attributes": {
+              "start_time": "2022-02-06T17:00:00.000Z",
+              "room": "Stora salongen",
+              "createdAt": "2022-01-23T10:32:29.220Z",
+              "updatedAt": "2022-01-23T10:32:29.220Z",
+              "movie": {
+                  "data": {
+                      "id": 4,
+                      "attributes": {
+                          "title": "The Dark Knight",
+                          "imdbId": "tt0468569",
+                          "intro": "When the menace known as the Joker wreaks havoc and chaos on the people of Gotham, **Batman** must accept one of the greatest psychological and physical tests of his ability to fight injustice.\n\nSee more info [on IMDB](https://imdb.com/title/tt0468569)",
+                          "image": {
+                              "url": "https://m.media-amazon.com/images/M/MV5BMTMxNTMwODM0NF5BMl5BanBnXkFtZTcwODAyMTk2Mw@@._V1_.jpg"
+                          },
+                          "createdAt": "2022-01-17T05:00:58.423Z",
+                          "updatedAt": "2022-01-18T08:47:52.866Z",
+                          "publishedAt": "2022-01-17T05:01:00.594Z"
+                      }
+                  }
+              }
+          }
+      },
+      {
+          "id": 55,
+          "attributes": {
+              "start_time": "2022-02-06T19:00:00.000Z",
+              "room": "Stora salongen",
+              "createdAt": "2022-01-23T10:32:30.046Z",
+              "updatedAt": "2022-01-23T10:32:30.046Z",
+              "movie": {
+                  "data": {
+                      "id": 5,
+                      "attributes": {
+                          "title": "12 Angry Men",
+                          "imdbId": "tt0050083",
+                          "intro": "The jury in a New York City murder trial is frustrated by a single member whose skeptical caution forces them to more carefully consider the evidence before jumping to a hasty verdict.\n\nSee more info [on IMDB](https://imdb.com/title/tt0050083)",
+                          "image": {
+                              "url": "https://m.media-amazon.com/images/M/MV5BMWU4N2FjNzYtNTVkNC00NzQ0LTg0MjAtYTJlMjFhNGUxZDFmXkEyXkFqcGdeQXVyNjc1NTYyMjg@._V1_.jpg"
+                          },
+                          "createdAt": "2022-01-17T05:01:21.807Z",
+                          "updatedAt": "2022-01-18T08:48:15.429Z",
+                          "publishedAt": "2022-01-17T05:01:24.036Z"
+                      }
+                  }
+              }
+          }
+      },
+      {
+          "id": 56,
+          "attributes": {
+              "start_time": "2022-02-06T21:00:00.000Z",
+              "room": "Stora salongen",
+              "createdAt": "2022-01-23T10:32:30.580Z",
+              "updatedAt": "2022-01-23T10:32:30.580Z",
+              "movie": {
+                  "data": {
+                      "id": 3,
+                      "attributes": {
+                          "title": "The Godfather: Part II",
+                          "imdbId": "tt0071562",
+                          "intro": "The early life and career of **Vito Corleone** in 1920s New York City is portrayed, while his son, **Michael**, expands and tightens his grip on the family crime syndicate.\n\nSee more info [on IMDB](https://imdb.com/title/tt0071562)",
+                          "image": {
+                              "url": "https://m.media-amazon.com/images/M/MV5BMWMwMGQzZTItY2JlNC00OWZiLWIyMDctNDk2ZDQ2YjRjMWQ0XkEyXkFqcGdeQXVyNzkwMjQ5NzM@._V1_.jpg"
+                          },
+                          "createdAt": "2022-01-17T05:00:31.562Z",
+                          "updatedAt": "2022-01-18T08:46:47.388Z",
+                          "publishedAt": "2022-01-17T05:00:33.453Z"
+                      }
+                  }
+              }
+          }
+      },
+      {
+          "id": 57,
+          "attributes": {
+              "start_time": "2022-02-07T12:00:00.000Z",
+              "room": "Stora salongen",
+              "createdAt": "2022-01-23T10:32:31.119Z",
+              "updatedAt": "2022-01-23T10:32:31.119Z",
+              "movie": {
+                  "data": {
+                      "id": 4,
+                      "attributes": {
+                          "title": "The Dark Knight",
+                          "imdbId": "tt0468569",
+                          "intro": "When the menace known as the Joker wreaks havoc and chaos on the people of Gotham, **Batman** must accept one of the greatest psychological and physical tests of his ability to fight injustice.\n\nSee more info [on IMDB](https://imdb.com/title/tt0468569)",
+                          "image": {
+                              "url": "https://m.media-amazon.com/images/M/MV5BMTMxNTMwODM0NF5BMl5BanBnXkFtZTcwODAyMTk2Mw@@._V1_.jpg"
+                          },
+                          "createdAt": "2022-01-17T05:00:58.423Z",
+                          "updatedAt": "2022-01-18T08:47:52.866Z",
+                          "publishedAt": "2022-01-17T05:01:00.594Z"
+                      }
+                  }
+              }
+          }
+      },
+      {
+          "id": 58,
+          "attributes": {
+              "start_time": "2022-02-07T17:00:00.000Z",
+              "room": "Stora salongen",
+              "createdAt": "2022-01-23T10:32:31.650Z",
+              "updatedAt": "2022-01-23T10:32:31.650Z",
+              "movie": {
+                  "data": {
+                      "id": 3,
+                      "attributes": {
+                          "title": "The Godfather: Part II",
+                          "imdbId": "tt0071562",
+                          "intro": "The early life and career of **Vito Corleone** in 1920s New York City is portrayed, while his son, **Michael**, expands and tightens his grip on the family crime syndicate.\n\nSee more info [on IMDB](https://imdb.com/title/tt0071562)",
+                          "image": {
+                              "url": "https://m.media-amazon.com/images/M/MV5BMWMwMGQzZTItY2JlNC00OWZiLWIyMDctNDk2ZDQ2YjRjMWQ0XkEyXkFqcGdeQXVyNzkwMjQ5NzM@._V1_.jpg"
+                          },
+                          "createdAt": "2022-01-17T05:00:31.562Z",
+                          "updatedAt": "2022-01-18T08:46:47.388Z",
+                          "publishedAt": "2022-01-17T05:00:33.453Z"
+                      }
+                  }
+              }
+          }
+      },
+      {
+          "id": 59,
+          "attributes": {
+              "start_time": "2022-02-07T19:00:00.000Z",
+              "room": "Stora salongen",
+              "createdAt": "2022-01-23T10:32:32.213Z",
+              "updatedAt": "2022-01-23T10:32:32.213Z",
+              "movie": {
+                  "data": {
+                      "id": 8,
+                      "attributes": {
+                          "title": "Idiocracy",
+                          "imdbId": "tt0387808",
+                          "intro": "Private **Joe Bauers**, a decisively average American, is selected as a guinea pig for a top-secret hibernation program but is forgotten, awakening to a future so incredibly moronic he's easily the most intelligent person alive.\n\nSee more info [on IMDB](https://imdb.com/title/tt0387808)",
+                          "image": {
+                              "url": "https://m.media-amazon.com/images/M/MV5BMWQ4MzI2ZDQtYjk3MS00ODdjLTkwN2QtOTBjYzIwM2RmNzgyXkEyXkFqcGdeQXVyMTQxNzMzNDI@._V1_.jpg"
+                          },
+                          "createdAt": "2022-01-17T09:32:08.570Z",
+                          "updatedAt": "2022-01-18T08:48:02.876Z",
+                          "publishedAt": "2022-01-17T09:32:12.868Z"
+                      }
+                  }
+              }
+          }
+      },
+      {
+          "id": 60,
+          "attributes": {
+              "start_time": "2022-02-07T21:00:00.000Z",
+              "room": "Stora salongen",
+              "createdAt": "2022-01-23T10:32:32.752Z",
+              "updatedAt": "2022-01-23T10:32:32.752Z",
+              "movie": {
+                  "data": {
+                      "id": 3,
+                      "attributes": {
+                          "title": "The Godfather: Part II",
+                          "imdbId": "tt0071562",
+                          "intro": "The early life and career of **Vito Corleone** in 1920s New York City is portrayed, while his son, **Michael**, expands and tightens his grip on the family crime syndicate.\n\nSee more info [on IMDB](https://imdb.com/title/tt0071562)",
+                          "image": {
+                              "url": "https://m.media-amazon.com/images/M/MV5BMWMwMGQzZTItY2JlNC00OWZiLWIyMDctNDk2ZDQ2YjRjMWQ0XkEyXkFqcGdeQXVyNzkwMjQ5NzM@._V1_.jpg"
+                          },
+                          "createdAt": "2022-01-17T05:00:31.562Z",
+                          "updatedAt": "2022-01-18T08:46:47.388Z",
+                          "publishedAt": "2022-01-17T05:00:33.453Z"
+                      }
+                  }
+              }
+          }
+      },
+      {
+          "id": 61,
+          "attributes": {
+              "start_time": "2022-02-08T12:00:00.000Z",
+              "room": "Stora salongen",
+              "createdAt": "2022-01-23T10:32:33.367Z",
+              "updatedAt": "2022-01-23T10:32:33.367Z",
+              "movie": {
+                  "data": {
+                      "id": 4,
+                      "attributes": {
+                          "title": "The Dark Knight",
+                          "imdbId": "tt0468569",
+                          "intro": "When the menace known as the Joker wreaks havoc and chaos on the people of Gotham, **Batman** must accept one of the greatest psychological and physical tests of his ability to fight injustice.\n\nSee more info [on IMDB](https://imdb.com/title/tt0468569)",
+                          "image": {
+                              "url": "https://m.media-amazon.com/images/M/MV5BMTMxNTMwODM0NF5BMl5BanBnXkFtZTcwODAyMTk2Mw@@._V1_.jpg"
+                          },
+                          "createdAt": "2022-01-17T05:00:58.423Z",
+                          "updatedAt": "2022-01-18T08:47:52.866Z",
+                          "publishedAt": "2022-01-17T05:01:00.594Z"
+                      }
+                  }
+              }
+          }
+      },
+      {
+          "id": 62,
+          "attributes": {
+              "start_time": "2022-02-08T17:00:00.000Z",
+              "room": "Stora salongen",
+              "createdAt": "2022-01-23T10:32:33.919Z",
+              "updatedAt": "2022-01-23T10:32:33.919Z",
+              "movie": {
+                  "data": {
+                      "id": 5,
+                      "attributes": {
+                          "title": "12 Angry Men",
+                          "imdbId": "tt0050083",
+                          "intro": "The jury in a New York City murder trial is frustrated by a single member whose skeptical caution forces them to more carefully consider the evidence before jumping to a hasty verdict.\n\nSee more info [on IMDB](https://imdb.com/title/tt0050083)",
+                          "image": {
+                              "url": "https://m.media-amazon.com/images/M/MV5BMWU4N2FjNzYtNTVkNC00NzQ0LTg0MjAtYTJlMjFhNGUxZDFmXkEyXkFqcGdeQXVyNjc1NTYyMjg@._V1_.jpg"
+                          },
+                          "createdAt": "2022-01-17T05:01:21.807Z",
+                          "updatedAt": "2022-01-18T08:48:15.429Z",
+                          "publishedAt": "2022-01-17T05:01:24.036Z"
+                      }
+                  }
+              }
+          }
+      },
+      {
+          "id": 63,
+          "attributes": {
+              "start_time": "2022-02-08T19:00:00.000Z",
+              "room": "Stora salongen",
+              "createdAt": "2022-01-23T10:32:34.469Z",
+              "updatedAt": "2022-01-23T10:32:34.469Z",
+              "movie": {
+                  "data": {
+                      "id": 10,
+                      "attributes": {
+                          "title": "Threat Level Midnight: The Movie",
+                          "imdbId": "tt11620828",
+                          "intro": "After secret agent **Michael Scarn** (played by Steve Carell) is forced into retirement due to the death of his wife **Catherine Zeta-Scarn**, the President of the United States of America (played by Craig Robinson) requests that he prevents **Goldenface** (played by John Krasinski) from blowing up the NHL All-Star Game and killing several hostages.\n\nSee more info [on IMDB](https://imdb.com/title/tt11620828)",
+                          "image": {
+                              "url": "https://m.media-amazon.com/images/M/MV5BZjMzNzE4ZGItMDI5Zi00ZjE3LThkODctYTlhZWY1ZTdmMGNjXkEyXkFqcGdeQXVyOTExNzM4NDM@._V1_.jpg"
+                          },
+                          "createdAt": "2022-01-17T10:51:45.145Z",
+                          "updatedAt": "2022-01-18T08:47:13.309Z",
+                          "publishedAt": "2022-01-17T10:51:53.355Z"
+                      }
+                  }
+              }
+          }
+      },
+      {
+          "id": 64,
+          "attributes": {
+              "start_time": "2022-02-08T21:00:00.000Z",
+              "room": "Stora salongen",
+              "createdAt": "2022-01-23T10:32:35.006Z",
+              "updatedAt": "2022-01-23T10:32:35.006Z",
+              "movie": {
+                  "data": {
+                      "id": 10,
+                      "attributes": {
+                          "title": "Threat Level Midnight: The Movie",
+                          "imdbId": "tt11620828",
+                          "intro": "After secret agent **Michael Scarn** (played by Steve Carell) is forced into retirement due to the death of his wife **Catherine Zeta-Scarn**, the President of the United States of America (played by Craig Robinson) requests that he prevents **Goldenface** (played by John Krasinski) from blowing up the NHL All-Star Game and killing several hostages.\n\nSee more info [on IMDB](https://imdb.com/title/tt11620828)",
+                          "image": {
+                              "url": "https://m.media-amazon.com/images/M/MV5BZjMzNzE4ZGItMDI5Zi00ZjE3LThkODctYTlhZWY1ZTdmMGNjXkEyXkFqcGdeQXVyOTExNzM4NDM@._V1_.jpg"
+                          },
+                          "createdAt": "2022-01-17T10:51:45.145Z",
+                          "updatedAt": "2022-01-18T08:47:13.309Z",
+                          "publishedAt": "2022-01-17T10:51:53.355Z"
+                      }
+                  }
+              }
+          }
+      },
+      {
+          "id": 65,
+          "attributes": {
+              "start_time": "2022-02-09T12:00:00.000Z",
+              "room": "Stora salongen",
+              "createdAt": "2022-01-23T10:32:35.544Z",
+              "updatedAt": "2022-01-23T10:32:35.544Z",
+              "movie": {
+                  "data": {
+                      "id": 10,
+                      "attributes": {
+                          "title": "Threat Level Midnight: The Movie",
+                          "imdbId": "tt11620828",
+                          "intro": "After secret agent **Michael Scarn** (played by Steve Carell) is forced into retirement due to the death of his wife **Catherine Zeta-Scarn**, the President of the United States of America (played by Craig Robinson) requests that he prevents **Goldenface** (played by John Krasinski) from blowing up the NHL All-Star Game and killing several hostages.\n\nSee more info [on IMDB](https://imdb.com/title/tt11620828)",
+                          "image": {
+                              "url": "https://m.media-amazon.com/images/M/MV5BZjMzNzE4ZGItMDI5Zi00ZjE3LThkODctYTlhZWY1ZTdmMGNjXkEyXkFqcGdeQXVyOTExNzM4NDM@._V1_.jpg"
+                          },
+                          "createdAt": "2022-01-17T10:51:45.145Z",
+                          "updatedAt": "2022-01-18T08:47:13.309Z",
+                          "publishedAt": "2022-01-17T10:51:53.355Z"
+                      }
+                  }
+              }
+          }
+      },
+      {
+          "id": 66,
+          "attributes": {
+              "start_time": "2022-02-09T17:00:00.000Z",
+              "room": "Stora salongen",
+              "createdAt": "2022-01-23T10:32:36.075Z",
+              "updatedAt": "2022-01-23T10:32:36.075Z",
+              "movie": {
+                  "data": {
+                      "id": 4,
+                      "attributes": {
+                          "title": "The Dark Knight",
+                          "imdbId": "tt0468569",
+                          "intro": "When the menace known as the Joker wreaks havoc and chaos on the people of Gotham, **Batman** must accept one of the greatest psychological and physical tests of his ability to fight injustice.\n\nSee more info [on IMDB](https://imdb.com/title/tt0468569)",
+                          "image": {
+                              "url": "https://m.media-amazon.com/images/M/MV5BMTMxNTMwODM0NF5BMl5BanBnXkFtZTcwODAyMTk2Mw@@._V1_.jpg"
+                          },
+                          "createdAt": "2022-01-17T05:00:58.423Z",
+                          "updatedAt": "2022-01-18T08:47:52.866Z",
+                          "publishedAt": "2022-01-17T05:01:00.594Z"
+                      }
+                  }
+              }
+          }
+      },
+      {
+          "id": 67,
+          "attributes": {
+              "start_time": "2022-02-09T19:00:00.000Z",
+              "room": "Stora salongen",
+              "createdAt": "2022-01-23T10:32:36.776Z",
+              "updatedAt": "2022-01-23T10:32:36.776Z",
+              "movie": {
+                  "data": {
+                      "id": 5,
+                      "attributes": {
+                          "title": "12 Angry Men",
+                          "imdbId": "tt0050083",
+                          "intro": "The jury in a New York City murder trial is frustrated by a single member whose skeptical caution forces them to more carefully consider the evidence before jumping to a hasty verdict.\n\nSee more info [on IMDB](https://imdb.com/title/tt0050083)",
+                          "image": {
+                              "url": "https://m.media-amazon.com/images/M/MV5BMWU4N2FjNzYtNTVkNC00NzQ0LTg0MjAtYTJlMjFhNGUxZDFmXkEyXkFqcGdeQXVyNjc1NTYyMjg@._V1_.jpg"
+                          },
+                          "createdAt": "2022-01-17T05:01:21.807Z",
+                          "updatedAt": "2022-01-18T08:48:15.429Z",
+                          "publishedAt": "2022-01-17T05:01:24.036Z"
+                      }
+                  }
+              }
+          }
+      },
+      {
+          "id": 68,
+          "attributes": {
+              "start_time": "2022-02-09T21:00:00.000Z",
+              "room": "Stora salongen",
+              "createdAt": "2022-01-23T10:32:37.605Z",
+              "updatedAt": "2022-01-23T10:32:37.605Z",
+              "movie": {
+                  "data": {
+                      "id": 1,
+                      "attributes": {
+                          "title": "The Shawshank Redemption",
+                          "imdbId": "tt0111161",
+                          "intro": "Two imprisoned men bond over a number of years, finding solace and eventual redemption through acts of common decency.\n\nSee more info [on IMDB](https://imdb.com/title/tt0111161)",
+                          "image": {
+                              "url": "https://m.media-amazon.com/images/M/MV5BMDFkYTc0MGEtZmNhMC00ZDIzLWFmNTEtODM1ZmRlYWMwMWFmXkEyXkFqcGdeQXVyMTMxODk2OTU@._V1_.jpg"
+                          },
+                          "createdAt": "2022-01-17T04:59:14.315Z",
+                          "updatedAt": "2022-01-18T08:47:01.417Z",
+                          "publishedAt": "2022-01-17T04:59:16.846Z"
+                      }
+                  }
+              }
+          }
+      },
+      {
+          "id": 69,
+          "attributes": {
+              "start_time": "2022-02-10T12:00:00.000Z",
+              "room": "Stora salongen",
+              "createdAt": "2022-01-23T10:32:38.433Z",
+              "updatedAt": "2022-01-23T10:32:38.433Z",
+              "movie": {
+                  "data": {
+                      "id": 5,
+                      "attributes": {
+                          "title": "12 Angry Men",
+                          "imdbId": "tt0050083",
+                          "intro": "The jury in a New York City murder trial is frustrated by a single member whose skeptical caution forces them to more carefully consider the evidence before jumping to a hasty verdict.\n\nSee more info [on IMDB](https://imdb.com/title/tt0050083)",
+                          "image": {
+                              "url": "https://m.media-amazon.com/images/M/MV5BMWU4N2FjNzYtNTVkNC00NzQ0LTg0MjAtYTJlMjFhNGUxZDFmXkEyXkFqcGdeQXVyNjc1NTYyMjg@._V1_.jpg"
+                          },
+                          "createdAt": "2022-01-17T05:01:21.807Z",
+                          "updatedAt": "2022-01-18T08:48:15.429Z",
+                          "publishedAt": "2022-01-17T05:01:24.036Z"
+                      }
+                  }
+              }
+          }
+      },
+      {
+          "id": 70,
+          "attributes": {
+              "start_time": "2022-02-10T17:00:00.000Z",
+              "room": "Stora salongen",
+              "createdAt": "2022-01-23T10:32:39.247Z",
+              "updatedAt": "2022-01-23T10:32:39.247Z",
+              "movie": {
+                  "data": {
+                      "id": 2,
+                      "attributes": {
+                          "title": "The Godfather",
+                          "imdbId": "tt0068646",
+                          "intro": "The Godfather follows **Vito Corleone**, Don of the Corleone family, as he passes the mantel to his unwilling son, **Michael**.\n\nSee more info [on IMDB](https://imdb.com/title/tt0068646)",
+                          "image": {
+                              "url": "https://m.media-amazon.com/images/M/MV5BM2MyNjYxNmUtYTAwNi00MTYxLWJmNWYtYzZlODY3ZTk3OTFlXkEyXkFqcGdeQXVyNzkwMjQ5NzM@._V1_.jpg"
+                          },
+                          "createdAt": "2022-01-17T04:59:42.763Z",
+                          "updatedAt": "2022-01-18T08:47:25.840Z",
+                          "publishedAt": "2022-01-17T04:59:44.929Z"
+                      }
+                  }
+              }
+          }
+      },
+      {
+          "id": 71,
+          "attributes": {
+              "start_time": "2022-02-10T19:00:00.000Z",
+              "room": "Stora salongen",
+              "createdAt": "2022-01-23T10:32:39.883Z",
+              "updatedAt": "2022-01-23T10:32:39.883Z",
+              "movie": {
+                  "data": {
+                      "id": 5,
+                      "attributes": {
+                          "title": "12 Angry Men",
+                          "imdbId": "tt0050083",
+                          "intro": "The jury in a New York City murder trial is frustrated by a single member whose skeptical caution forces them to more carefully consider the evidence before jumping to a hasty verdict.\n\nSee more info [on IMDB](https://imdb.com/title/tt0050083)",
+                          "image": {
+                              "url": "https://m.media-amazon.com/images/M/MV5BMWU4N2FjNzYtNTVkNC00NzQ0LTg0MjAtYTJlMjFhNGUxZDFmXkEyXkFqcGdeQXVyNjc1NTYyMjg@._V1_.jpg"
+                          },
+                          "createdAt": "2022-01-17T05:01:21.807Z",
+                          "updatedAt": "2022-01-18T08:48:15.429Z",
+                          "publishedAt": "2022-01-17T05:01:24.036Z"
+                      }
+                  }
+              }
+          }
+      },
+      {
+          "id": 72,
+          "attributes": {
+              "start_time": "2022-02-10T21:00:00.000Z",
+              "room": "Stora salongen",
+              "createdAt": "2022-01-23T10:32:40.408Z",
+              "updatedAt": "2022-01-23T10:32:40.408Z",
+              "movie": {
+                  "data": {
+                      "id": 10,
+                      "attributes": {
+                          "title": "Threat Level Midnight: The Movie",
+                          "imdbId": "tt11620828",
+                          "intro": "After secret agent **Michael Scarn** (played by Steve Carell) is forced into retirement due to the death of his wife **Catherine Zeta-Scarn**, the President of the United States of America (played by Craig Robinson) requests that he prevents **Goldenface** (played by John Krasinski) from blowing up the NHL All-Star Game and killing several hostages.\n\nSee more info [on IMDB](https://imdb.com/title/tt11620828)",
+                          "image": {
+                              "url": "https://m.media-amazon.com/images/M/MV5BZjMzNzE4ZGItMDI5Zi00ZjE3LThkODctYTlhZWY1ZTdmMGNjXkEyXkFqcGdeQXVyOTExNzM4NDM@._V1_.jpg"
+                          },
+                          "createdAt": "2022-01-17T10:51:45.145Z",
+                          "updatedAt": "2022-01-18T08:47:13.309Z",
+                          "publishedAt": "2022-01-17T10:51:53.355Z"
+                      }
+                  }
+              }
+          }
+      },
+      {
+          "id": 73,
+          "attributes": {
+              "start_time": "2022-02-11T12:00:00.000Z",
+              "room": "Stora salongen",
+              "createdAt": "2022-01-23T10:32:40.940Z",
+              "updatedAt": "2022-01-23T10:32:40.940Z",
+              "movie": {
+                  "data": {
+                      "id": 5,
+                      "attributes": {
+                          "title": "12 Angry Men",
+                          "imdbId": "tt0050083",
+                          "intro": "The jury in a New York City murder trial is frustrated by a single member whose skeptical caution forces them to more carefully consider the evidence before jumping to a hasty verdict.\n\nSee more info [on IMDB](https://imdb.com/title/tt0050083)",
+                          "image": {
+                              "url": "https://m.media-amazon.com/images/M/MV5BMWU4N2FjNzYtNTVkNC00NzQ0LTg0MjAtYTJlMjFhNGUxZDFmXkEyXkFqcGdeQXVyNjc1NTYyMjg@._V1_.jpg"
+                          },
+                          "createdAt": "2022-01-17T05:01:21.807Z",
+                          "updatedAt": "2022-01-18T08:48:15.429Z",
+                          "publishedAt": "2022-01-17T05:01:24.036Z"
+                      }
+                  }
+              }
+          }
+      },
+      {
+          "id": 74,
+          "attributes": {
+              "start_time": "2022-02-11T17:00:00.000Z",
+              "room": "Stora salongen",
+              "createdAt": "2022-01-23T10:32:41.527Z",
+              "updatedAt": "2022-01-23T10:32:41.527Z",
+              "movie": {
+                  "data": {
+                      "id": 2,
+                      "attributes": {
+                          "title": "The Godfather",
+                          "imdbId": "tt0068646",
+                          "intro": "The Godfather follows **Vito Corleone**, Don of the Corleone family, as he passes the mantel to his unwilling son, **Michael**.\n\nSee more info [on IMDB](https://imdb.com/title/tt0068646)",
+                          "image": {
+                              "url": "https://m.media-amazon.com/images/M/MV5BM2MyNjYxNmUtYTAwNi00MTYxLWJmNWYtYzZlODY3ZTk3OTFlXkEyXkFqcGdeQXVyNzkwMjQ5NzM@._V1_.jpg"
+                          },
+                          "createdAt": "2022-01-17T04:59:42.763Z",
+                          "updatedAt": "2022-01-18T08:47:25.840Z",
+                          "publishedAt": "2022-01-17T04:59:44.929Z"
+                      }
+                  }
+              }
+          }
+      },
+      {
+          "id": 75,
+          "attributes": {
+              "start_time": "2022-02-11T19:00:00.000Z",
+              "room": "Stora salongen",
+              "createdAt": "2022-01-23T10:32:42.401Z",
+              "updatedAt": "2022-01-23T10:32:42.401Z",
+              "movie": {
+                  "data": {
+                      "id": 3,
+                      "attributes": {
+                          "title": "The Godfather: Part II",
+                          "imdbId": "tt0071562",
+                          "intro": "The early life and career of **Vito Corleone** in 1920s New York City is portrayed, while his son, **Michael**, expands and tightens his grip on the family crime syndicate.\n\nSee more info [on IMDB](https://imdb.com/title/tt0071562)",
+                          "image": {
+                              "url": "https://m.media-amazon.com/images/M/MV5BMWMwMGQzZTItY2JlNC00OWZiLWIyMDctNDk2ZDQ2YjRjMWQ0XkEyXkFqcGdeQXVyNzkwMjQ5NzM@._V1_.jpg"
+                          },
+                          "createdAt": "2022-01-17T05:00:31.562Z",
+                          "updatedAt": "2022-01-18T08:46:47.388Z",
+                          "publishedAt": "2022-01-17T05:00:33.453Z"
+                      }
+                  }
+              }
+          }
+      },
+      {
+          "id": 76,
+          "attributes": {
+              "start_time": "2022-02-11T21:00:00.000Z",
+              "room": "Stora salongen",
+              "createdAt": "2022-01-23T10:32:42.953Z",
+              "updatedAt": "2022-01-23T10:32:42.953Z",
+              "movie": {
+                  "data": {
+                      "id": 5,
+                      "attributes": {
+                          "title": "12 Angry Men",
+                          "imdbId": "tt0050083",
+                          "intro": "The jury in a New York City murder trial is frustrated by a single member whose skeptical caution forces them to more carefully consider the evidence before jumping to a hasty verdict.\n\nSee more info [on IMDB](https://imdb.com/title/tt0050083)",
+                          "image": {
+                              "url": "https://m.media-amazon.com/images/M/MV5BMWU4N2FjNzYtNTVkNC00NzQ0LTg0MjAtYTJlMjFhNGUxZDFmXkEyXkFqcGdeQXVyNjc1NTYyMjg@._V1_.jpg"
+                          },
+                          "createdAt": "2022-01-17T05:01:21.807Z",
+                          "updatedAt": "2022-01-18T08:48:15.429Z",
+                          "publishedAt": "2022-01-17T05:01:24.036Z"
+                      }
+                  }
+              }
+          }
+      },
+      {
+          "id": 77,
+          "attributes": {
+              "start_time": "2022-02-12T12:00:00.000Z",
+              "room": "Stora salongen",
+              "createdAt": "2022-01-23T10:32:43.668Z",
+              "updatedAt": "2022-01-23T10:32:43.668Z",
+              "movie": {
+                  "data": {
+                      "id": 3,
+                      "attributes": {
+                          "title": "The Godfather: Part II",
+                          "imdbId": "tt0071562",
+                          "intro": "The early life and career of **Vito Corleone** in 1920s New York City is portrayed, while his son, **Michael**, expands and tightens his grip on the family crime syndicate.\n\nSee more info [on IMDB](https://imdb.com/title/tt0071562)",
+                          "image": {
+                              "url": "https://m.media-amazon.com/images/M/MV5BMWMwMGQzZTItY2JlNC00OWZiLWIyMDctNDk2ZDQ2YjRjMWQ0XkEyXkFqcGdeQXVyNzkwMjQ5NzM@._V1_.jpg"
+                          },
+                          "createdAt": "2022-01-17T05:00:31.562Z",
+                          "updatedAt": "2022-01-18T08:46:47.388Z",
+                          "publishedAt": "2022-01-17T05:00:33.453Z"
+                      }
+                  }
+              }
+          }
+      },
+      {
+          "id": 78,
+          "attributes": {
+              "start_time": "2022-02-12T17:00:00.000Z",
+              "room": "Stora salongen",
+              "createdAt": "2022-01-23T10:32:44.202Z",
+              "updatedAt": "2022-01-23T10:32:44.202Z",
+              "movie": {
+                  "data": {
+                      "id": 5,
+                      "attributes": {
+                          "title": "12 Angry Men",
+                          "imdbId": "tt0050083",
+                          "intro": "The jury in a New York City murder trial is frustrated by a single member whose skeptical caution forces them to more carefully consider the evidence before jumping to a hasty verdict.\n\nSee more info [on IMDB](https://imdb.com/title/tt0050083)",
+                          "image": {
+                              "url": "https://m.media-amazon.com/images/M/MV5BMWU4N2FjNzYtNTVkNC00NzQ0LTg0MjAtYTJlMjFhNGUxZDFmXkEyXkFqcGdeQXVyNjc1NTYyMjg@._V1_.jpg"
+                          },
+                          "createdAt": "2022-01-17T05:01:21.807Z",
+                          "updatedAt": "2022-01-18T08:48:15.429Z",
+                          "publishedAt": "2022-01-17T05:01:24.036Z"
+                      }
+                  }
+              }
+          }
+      },
+      {
+          "id": 79,
+          "attributes": {
+              "start_time": "2022-02-12T19:00:00.000Z",
+              "room": "Stora salongen",
+              "createdAt": "2022-01-23T10:32:44.767Z",
+              "updatedAt": "2022-01-23T10:32:44.767Z",
+              "movie": {
+                  "data": {
+                      "id": 10,
+                      "attributes": {
+                          "title": "Threat Level Midnight: The Movie",
+                          "imdbId": "tt11620828",
+                          "intro": "After secret agent **Michael Scarn** (played by Steve Carell) is forced into retirement due to the death of his wife **Catherine Zeta-Scarn**, the President of the United States of America (played by Craig Robinson) requests that he prevents **Goldenface** (played by John Krasinski) from blowing up the NHL All-Star Game and killing several hostages.\n\nSee more info [on IMDB](https://imdb.com/title/tt11620828)",
+                          "image": {
+                              "url": "https://m.media-amazon.com/images/M/MV5BZjMzNzE4ZGItMDI5Zi00ZjE3LThkODctYTlhZWY1ZTdmMGNjXkEyXkFqcGdeQXVyOTExNzM4NDM@._V1_.jpg"
+                          },
+                          "createdAt": "2022-01-17T10:51:45.145Z",
+                          "updatedAt": "2022-01-18T08:47:13.309Z",
+                          "publishedAt": "2022-01-17T10:51:53.355Z"
+                      }
+                  }
+              }
+          }
+      },
+      {
+          "id": 80,
+          "attributes": {
+              "start_time": "2022-02-12T21:00:00.000Z",
+              "room": "Stora salongen",
+              "createdAt": "2022-01-23T10:32:45.313Z",
+              "updatedAt": "2022-01-23T10:32:45.313Z",
+              "movie": {
+                  "data": {
+                      "id": 2,
+                      "attributes": {
+                          "title": "The Godfather",
+                          "imdbId": "tt0068646",
+                          "intro": "The Godfather follows **Vito Corleone**, Don of the Corleone family, as he passes the mantel to his unwilling son, **Michael**.\n\nSee more info [on IMDB](https://imdb.com/title/tt0068646)",
+                          "image": {
+                              "url": "https://m.media-amazon.com/images/M/MV5BM2MyNjYxNmUtYTAwNi00MTYxLWJmNWYtYzZlODY3ZTk3OTFlXkEyXkFqcGdeQXVyNzkwMjQ5NzM@._V1_.jpg"
+                          },
+                          "createdAt": "2022-01-17T04:59:42.763Z",
+                          "updatedAt": "2022-01-18T08:47:25.840Z",
+                          "publishedAt": "2022-01-17T04:59:44.929Z"
+                      }
+                  }
+              }
+          }
+      }
+  ];

--- a/tests/screenings.spec.js
+++ b/tests/screenings.spec.js
@@ -1,16 +1,31 @@
-import {trimData} from '../src/screenings.js'
+import {jest} from '@jest/globals'
+import { trimData } from '../src/screenings.js'
 
-test('If array gets trimmed down to id, title, start_time, movieId and image', async () => {
-  const screeningsArray = data;
-  const trimmedDataObj = await trimData(screeningsArray);
-  console.log(trimmedDataObj.splice(0, 10));
+// Mock Date
+beforeEach(() => {
+  jest.useFakeTimers();
+  jest.setSystemTime(new Date(2022, 0, 27).getTime())
+});
 
-  expect(trimmedDataObj[0].id).toBeTruthy();
-  expect(trimmedDataObj[0].title).toBeTruthy();
-  expect(trimmedDataObj[0].start_time).toBeTruthy();
-  expect(trimmedDataObj[0].movieId).toBeTruthy();
-  expect(trimmedDataObj[0].image).toBeTruthy();
-})
+afterEach(() => {
+  jest.clearAllTimers();
+});
+
+test('If array gets trimmed down to id, title, start_time, movieId, room and image', async () => {
+  const screeningsArray = data.splice(0, 10);
+  const trimmedDataArray = await trimData(screeningsArray);
+
+  trimmedDataArray.forEach((screening) => {
+      expect(screening.id).toBeTruthy();
+      expect(screening.title).toBeTruthy();
+      expect(screening.start_time).toBeTruthy();
+      expect(screening.movieId).toBeTruthy();
+      expect(screening.image).toBeTruthy();
+      expect(screening.room).toBeTruthy();
+    });
+  });
+
+
 
 
 

--- a/tests/screenings.spec.js
+++ b/tests/screenings.spec.js
@@ -1,5 +1,9 @@
 import { jest } from '@jest/globals';
-import { trimData, filterOldScreenings } from '../src/screenings.js';
+import {
+  trimData,
+  filterOldScreenings,
+  filterNextFiveDaysScreenings,
+} from '../src/screenings.js';
 
 // Mock Date
 beforeEach(() => {
@@ -32,6 +36,22 @@ test('If old screenings are removed from array', async () => {
 
   filteredScreenings.forEach((screening) => {
     expect(Date.parse(screening.start_time) > Date.parse(date));
+  });
+});
+
+test('If only screenings five days ahead is in the array', async () => {
+  const date = new Date();
+  const ms = new Date().getTime() + 86400000 * 5;
+  const futureDate = new Date(ms);
+  const screeningsArray = await filterOldScreenings(trimData(data), date);
+
+  const futureScreenings = filterNextFiveDaysScreenings(
+    screeningsArray,
+    futureDate
+  );
+
+  futureScreenings.forEach((screening) => {
+    expect(Date.parse(screening.start_time) < Date.parse(futureDate));
   });
 });
 


### PR DESCRIPTION
As a costumer, i want to see upcoming showings on the frontpage, to quickly know if any showing fits my schedule

Branch: tic-1

Startsidan ska visa en lista på visningar de kommande dagarna. Listan ska laddas in med hjälp av webbläsarens fetch() EFTER att sidan har visats, d.v.s. inte renderas på servern.

- Endast visningar för de kommande fem dagarna ska visas

- Max 10 filmvisningar ska visas. Om det finns fler än 10 visningar de kommande fem dagarna ska bara så många dagar visas som resulterar i max 10 visningar.

- Ovanstående logik ska programmeras på servern, och testas med hjälp av ett enhetstest och mockade datakällor


Acceptance Criteria
Scenario: The user is looking for upcoming screenings on the cinema

Given: The user navigates to the middle of the main page

When: The user finds a section with the header "kommande visningar" and a list of upcomings screenings 

Then: The main page displays a list containing movie title, screening room, movie cover image, date and time. Each item in the list linked to movies page

Centered list
Movie cover image to the right of each list item
Movie title as header
Under the header screening room is listed
On the bottom of each list item is date and time for the screening
List item linked to movies page for displayed movie


Added README.md with short description of the API route and workings